### PR TITLE
Improve configuration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ tags
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
 
-
+# ignore them not to commit credentials
+instance/

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ marshmallow = "*"
 flask-cors = "*"
 cryptography = "*"
 mysql-connector-python = "*"
+psycopg2-binary = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cfcd1945a6b022b9f84ca0e748bd3ee6ba32cfd9d496e497d42288ae806ecc7e"
+            "sha256": "0224fd4f346e953da682f01e394b21e6fce5c27edd312676cd31071994780f29"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -96,11 +96,11 @@
         },
         "flask-cors": {
             "hashes": [
-                "sha256:a1bb895b3e98b4325743149ebe0e3a0652537b8e37854f942bde7843f822f129",
-                "sha256:bec996f0603a0693c0ea63c8126e5f8e966bb679cf82e6104b254e9c7f3a7d08"
+                "sha256:e4c8fc15d3e4b4cce6d3b325f2bab91e0e09811a61f50d7a53493bc44242a4f1",
+                "sha256:ecc016c5b32fa5da813ec8d272941cfddf5f6bba9060c405a70285415cbf24c9"
             ],
             "index": "pypi",
-            "version": "==3.0.4"
+            "version": "==3.0.6"
         },
         "flask-sqlalchemy": {
             "hashes": [
@@ -112,10 +112,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "itsdangerous": {
             "hashes": [
@@ -170,28 +170,56 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:01ccd6d03449ae75b779fb5bf4ed62177d61afe3c5e6465ccf3f8b2e1a84afbe",
-                "sha256:1d92cc30b0b46cced33adde5853d920179eb5ea8eecdee9552502a7f29cc3f21",
-                "sha256:242e4c7ae565267a8bc8b92d707177f915607ea4bd73244bec6cbf4a49b96661",
-                "sha256:3b60685732bd0cbdc802dfcb6071efbcf5d927ce3127c13c33ea1a8efae3aa76",
-                "sha256:3f655e1f99c3e14d56ca900af1b9a4715b691319a295cc38939d7f77eabd5e7c",
-                "sha256:560a38e692a69957a70ba0e5839aa67430efd63072bf91b0539dac19055694cd",
-                "sha256:5c1c8f6a0a68a874e3beff89255959dd80fad45870e96c88944a1b81a22dd5f5",
-                "sha256:628a3bf0794a8b3cabb18db11eb67cc10e0cc6e5525d557ae7b682bb73fa2018",
-                "sha256:7222d6616108b33ad6cbeff8117062a73c43cdc8fa8f64f6a322ebeb663e710e",
-                "sha256:76ef6ca3c50e4cfd044861586d5f1b352e0fe7f17f883df6c165bad5b4d0e10a",
-                "sha256:7c193e6964e752bd056735594826c5b03274ceb8f07349d3ae47d9766250ba96",
-                "sha256:869e12bcfb5759e683f53ec1dd6155b7be034065431da289f0cb4510040a0799",
-                "sha256:905414e5ea6cdb78d8730f66335755152b46685fcb9fc2f2134024e3ea9e8dcc",
-                "sha256:ac0067e3c60737865ed72bb7416e02297d229d960902802d874c0e167128c809",
-                "sha256:adf716a89c9cc1891ead79a861c427071ef59172f0e11967b00565a9547b3bd0",
-                "sha256:bcfa99f5a82f5eaaf6e5cee5bfdca5a1670f5740aec1d93dae170645ed1a16b0",
-                "sha256:cc94079ae6cbcea5ae194464a30f3223f075e06a0446f52bca9ddbeb6e9f412a",
-                "sha256:d5d9edfdc5a3a01d06062d677b121081629782edf0e05ca1be14f15bb947eeee",
-                "sha256:e269ab7a50bf0fa6fe6a88ea7dcc7a1079ae9450d9ab9b7730ac32916d55508b",
-                "sha256:e7fd33a3474cbe18fd5b5620784a0fa21fcae3e402b1806e29c6b450c7f61706"
+                "sha256:12985d9f40c104da2f44ec089449214876809b40fdc5d9e43b93b512b9e74056",
+                "sha256:12c97fe27af12fc5d66b23f905ab09dd4fb0c68d5a74a419d914580e6d2e71e3",
+                "sha256:327fb9d8a8247bc780b9ea7ed03c0643bc0d22c139b761c9ec1efc7cc3f0923e",
+                "sha256:3895319db04c0b3baed74fb66be7ba9f4cd8e88a432b8e71032cdf08b2dfee23",
+                "sha256:695072063e256d32335d48b9484451f7c7948edc3dbd419469d6a778602682fc",
+                "sha256:7d786f3ef5b33a04e6538089674f244a3b0f588155016559d950989010af97d0",
+                "sha256:8bf82bb7a466a54be7272dcb492f71d55a2453a58d862fb74c3f2083f2768543",
+                "sha256:9bbc1ae1c33c1bd3a2fc05a3aec328544d2b039ff0ce6f000063628a32fad777",
+                "sha256:9e992c68103ab5635728d29fcf132c669cb4e2db24d012685210276185009d17",
+                "sha256:9f1087abb67b34e55108bc610936b34363a7aac692023bcbb17e065c253a1f80",
+                "sha256:9fefcb92a3784b446abf3641d9a14dad815bee88e0edd10b9a9e0e144d01a991",
+                "sha256:a37836aa47d1b81c2db1a6b7a5e79926062b5d76bd962115a0e615551be2b48d",
+                "sha256:cca22955443c55cf86f963a4ad7057bca95e4dcde84d6a493066d380cfab3bb0",
+                "sha256:d7ac50bc06d31deb07ace6de85556c1d7330e5c0958f3b2af85037d6d1182abf",
+                "sha256:dfe6899304b898538f4dc94fa0b281b56b70e40f58afa4c6f807805261cbe2e8"
             ],
-            "version": "==3.5.2.post1"
+            "version": "==3.6.0"
+        },
+        "psycopg2-binary": {
+            "hashes": [
+                "sha256:04afb59bbbd2eab3148e6816beddc74348078b8c02a1113ea7f7822f5be4afe3",
+                "sha256:098b18f4d8857a8f9b206d1dc54db56c2255d5d26458917e7bcad61ebfe4338f",
+                "sha256:0bf855d4a7083e20ead961fda4923887094eaeace0ab2d76eb4aa300f4bbf5bd",
+                "sha256:197dda3ffd02057820be83fe4d84529ea70bf39a9a4daee1d20ffc74eb3d042e",
+                "sha256:278ef63afb4b3d842b4609f2c05ffbfb76795cf6a184deeb8707cd5ed3c981a5",
+                "sha256:3cbf8c4fc8f22f0817220891cf405831559f4d4c12c4f73913730a2ea6c47a47",
+                "sha256:4305aed922c4d9d6163ab3a41d80b5a1cfab54917467da8168552c42cad84d32",
+                "sha256:47ee296f704fb8b2a616dec691cdcfd5fa0f11943955e88faa98cbd1dc3b3e3d",
+                "sha256:4a0e38cb30457e70580903367161173d4a7d1381eb2f2cfe4e69b7806623f484",
+                "sha256:4d6c294c6638a71cafb82a37f182f24321f1163b08b5d5ca076e11fe838a3086",
+                "sha256:4f3233c366500730f839f92833194fd8f9a5c4529c8cd8040aa162c3740de8e5",
+                "sha256:5221f5a3f4ca2ddf0d58e8b8a32ca50948be9a43351fda797eb4e72d7a7aa34d",
+                "sha256:5c6ca0b507540a11eaf9e77dee4f07c131c2ec80ca0cffa146671bf690bc1c02",
+                "sha256:789bd89d71d704db2b3d5e67d6d518b158985d791d3b2dec5ab85457cfc9677b",
+                "sha256:89bc65ef3301c74cf32db25334421ea6adbe8f65601ea45dcaaf095abed910bb",
+                "sha256:97521704ac7127d7d8ba22877da3c7bf4a40366587d238ec679ff38e33177498",
+                "sha256:a6d32c37f714c3f34158f3fa659f3a8f2658d5f53c4297d45579b9677cc4d852",
+                "sha256:a89ee5c26f72f2d0d74b991ce49e42ddeb4ac0dc2d8c06a0f2770a1ab48f4fe0",
+                "sha256:b4c8b0ef3608e59317bfc501df84a61e48b5445d45f24d0391a24802de5f2d84",
+                "sha256:b5fcf07140219a1f71e18486b8dc28e2e1b76a441c19374805c617aa6d9a9d55",
+                "sha256:b86f527f00956ecebad6ab3bb30e3a75fedf1160a8716978dd8ce7adddedd86f",
+                "sha256:be4c4aa22ba22f70de36c98b06480e2f1697972d49eb20d525f400d204a6d272",
+                "sha256:c2ac7aa1a144d4e0e613ac7286dae85671e99fe7a1353954d4905629c36b811c",
+                "sha256:de26ef4787b5e778e8223913a3e50368b44e7480f83c76df1f51d23bd21cea16",
+                "sha256:e70ebcfc5372dc7b699c0110454fc4263967f30c55454397e5769eb72c0eb0ce",
+                "sha256:eadbd32b6bc48b67b0457fccc94c86f7ccc8178ab839f684eb285bb592dc143e",
+                "sha256:ecbc6dfff6db06b8b72ae8a2f25ff20fbdcb83cb543811a08f7cb555042aa729"
+            ],
+            "index": "pypi",
+            "version": "==2.7.5"
         },
         "pycparser": {
             "hashes": [

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ from sqlalchemy.exc import ProgrammingError
 from .routes import auth, api
 from .models import db
 import os
+import sys
 
 config = {
     "development": "api.config.DevelopmentConfig",
@@ -23,6 +24,14 @@ def create_app():
 
     app.config.from_object(config[config_name])
     app.config.from_pyfile('config.cfg', silent=True)
+
+    if app.config.get('SQLALCHEMY_DATABASE_URI', None) is None:
+        app.logger.error("SQLALCHEMY_DATABASE_URI is not set. Didn't you forget to set it in instance/config.cfg?")
+        sys.exit(4) # Return 4 to exit gunicorn
+
+    if app.config.get('SECRET_KEY', None) is None:
+        app.logger.error("SECRET_KEY is not set Didn't you forget to set it in instance/config.cfg?")
+        sys.exit(4) # Return 4 to exit gunicorn
 
     db.init_app(app)
 

--- a/api/app.py
+++ b/api/app.py
@@ -4,11 +4,24 @@ from sqlalchemy.exc import ProgrammingError
 from .routes import auth, api
 from .models import db
 
+config = {
+    "development": "config.DevelopmentConfig",
+    "testing": "config.TestingConfig",
+    "preview": "config.PreviewDeploymentConfig",
+    "deployment": "config.DeploymentConfig",
+    "default": "config.DevelopmentConfig"
+}
 
 def create_app(config=None):
-    app = Flask(__name__)
+    app = Flask(__name__, instance_relative_config=True)
     # load app sepcified configuration
     CORS(app, supports_credentials=True)
+
+    config_name = os.getenv('FLASK_CONFIGURATION', 'default')
+
+    app.config.from_object(config[config_name])
+    app.config.from_pyfile('config.cfg', silent=True)
+
     if config is not None:
         if isinstance(config, dict):
             app.config.update(config)

--- a/api/app.py
+++ b/api/app.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 from sqlalchemy.exc import ProgrammingError
 from .routes import auth, api
 from .models import db
+import os
 
 config = {
     "development": "config.DevelopmentConfig",

--- a/api/app.py
+++ b/api/app.py
@@ -6,11 +6,11 @@ from .models import db
 import os
 
 config = {
-    "development": "config.DevelopmentConfig",
-    "testing": "config.TestingConfig",
-    "preview": "config.PreviewDeploymentConfig",
-    "deployment": "config.DeploymentConfig",
-    "default": "config.DevelopmentConfig"
+    "development": "api.config.DevelopmentConfig",
+    "testing": "api.config.TestingConfig",
+    "preview": "api.config.PreviewDeploymentConfig",
+    "deployment": "api.config.DeploymentConfig",
+    "default": "api.config.DevelopmentConfig"
 }
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,7 @@ config = {
     "default": "config.DevelopmentConfig"
 }
 
+
 def create_app(config=None):
     app = Flask(__name__, instance_relative_config=True)
     # load app sepcified configuration

--- a/api/app.py
+++ b/api/app.py
@@ -14,7 +14,7 @@ config = {
 }
 
 
-def create_app(config=None):
+def create_app():
     app = Flask(__name__, instance_relative_config=True)
     # load app sepcified configuration
     CORS(app, supports_credentials=True)
@@ -23,12 +23,6 @@ def create_app(config=None):
 
     app.config.from_object(config[config_name])
     app.config.from_pyfile('config.cfg', silent=True)
-
-    if config is not None:
-        if isinstance(config, dict):
-            app.config.update(config)
-        elif config.endswith('.py'):
-            app.config.from_pyfile(config)
 
     db.init_app(app)
 

--- a/api/app.py
+++ b/api/app.py
@@ -9,7 +9,6 @@ import sys
 config = {
     "development": "api.config.DevelopmentConfig",
     "testing": "api.config.TestingConfig",
-    "preview": "api.config.PreviewDeploymentConfig",
     "deployment": "api.config.DeploymentConfig",
     "default": "api.config.DevelopmentConfig"
 }

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,27 @@
+from cryptography.fernet import Fernet
+
+class BaseConfig(object):
+    DEBUG = False
+    TESTING = False
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_DATABASE_URI = 'mysql+mysqlconnector://root:password@mysql/db'
+    SECRET_KEY = Fernet.generate_key()
+
+class DevelopmentConfig(BaseConfig):
+    DEBUG = True
+    TESTING = True
+
+class TestingConfig(BaseConfig):
+    DEBUG = False
+    TESTING = True
+
+class PreviewDeploymentConfig(BaseConfig):
+    DEBUG = False
+    TESTING = False
+    SQLALCHEMY_DATABASE_URI = 'sqlite://'
+
+class DeploymentConfig(PreviewDeploymentConfig):
+    # None, to be configured in config.cfg in instance directory
+    SQLALCHEMY_DATABASE_URI = None
+    SECRET_KEY = None
+

--- a/api/config.py
+++ b/api/config.py
@@ -12,20 +12,24 @@ class BaseConfig(object):
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
     TESTING = True
+    ENV = 'development'
 
 
 class TestingConfig(BaseConfig):
     DEBUG = False
     TESTING = True
+    ENV = 'development'
 
 
 class PreviewDeploymentConfig(BaseConfig):
     DEBUG = False
     TESTING = False
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
+    ENV = 'development'
 
 
 class DeploymentConfig(PreviewDeploymentConfig):
     # None, to be configured in config.cfg in instance directory
     SQLALCHEMY_DATABASE_URI = None
     SECRET_KEY = None
+    ENV = 'production'

--- a/api/config.py
+++ b/api/config.py
@@ -20,15 +20,9 @@ class TestingConfig(BaseConfig):
     TESTING = True
     ENV = 'development'
 
-
-class PreviewDeploymentConfig(BaseConfig):
+class DeploymentConfig(BaseConfig):
     DEBUG = False
     TESTING = False
-    SQLALCHEMY_DATABASE_URI = 'sqlite://'
-    ENV = 'development'
-
-
-class DeploymentConfig(PreviewDeploymentConfig):
     # None, to be configured in config.cfg in instance directory
     SQLALCHEMY_DATABASE_URI = None
     SECRET_KEY = None

--- a/api/config.py
+++ b/api/config.py
@@ -1,5 +1,6 @@
 from cryptography.fernet import Fernet
 
+
 class BaseConfig(object):
     DEBUG = False
     TESTING = False
@@ -7,21 +8,24 @@ class BaseConfig(object):
     SQLALCHEMY_DATABASE_URI = 'mysql+mysqlconnector://root:password@mysql/db'
     SECRET_KEY = Fernet.generate_key()
 
+
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
     TESTING = True
 
+
 class TestingConfig(BaseConfig):
     DEBUG = False
     TESTING = True
+
 
 class PreviewDeploymentConfig(BaseConfig):
     DEBUG = False
     TESTING = False
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
+
 class DeploymentConfig(PreviewDeploymentConfig):
     # None, to be configured in config.cfg in instance directory
     SQLALCHEMY_DATABASE_URI = None
     SECRET_KEY = None
-

--- a/api/config.py
+++ b/api/config.py
@@ -5,7 +5,7 @@ class BaseConfig(object):
     DEBUG = False
     TESTING = False
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = 'mysql+mysqlconnector://root:password@mysql/db'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@db/postgres'
     SECRET_KEY = Fernet.generate_key()
 
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,6 @@
 from api.app import create_app, initdb, generate
-from cryptography.fernet import Fernet
 
-app = create_app({
-    'SECRET_KEY': Fernet.generate_key(),
-    'SQLALCHEMY_TRACK_MODIFICATIONS': False,
-    'SQLALCHEMY_DATABASE_URI': 'mysql+mysqlconnector://root:password@mysql/db',
-})
+app = create_app()
 
 
 @app.cli.command("initdb")


### PR DESCRIPTION
デプロイ時に機密を直書きすることのないように...

今まではFLASK_ENVとかを外から適当に突っ込んでたわけですが、これで`FLASK_CONFIGURATION`環境変数をみて設定を分けていくことになります

FLASK_CONFIGUTATIONの値一覧:

- development
開発用です。デバッグとかテストとか入ってます。MySQL。
- testing
テスト用です。テスト機能が入ってます。MySQL。
- preview
プレビューデプロイ用。sqlite。何がやりたかったかというとnowなんだけど、Heroku使えばMySQLでなんとかできるかもしれないので検討。
- deployment
デプロイ用。MySQLのパスとか暗号化キー等を`instance/config.cfg`に隠蔽する。
- default
= development
