### PR TITLE
複数人当選するようにする #66

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,8 +1,6 @@
 from cryptography.fernet import Fernet
 import os
 
-# =========== value configs ==========
-WINNERS_NUM = 90 # default: 90
 
 
 class BaseConfig(object):

--- a/api/config.py
+++ b/api/config.py
@@ -8,7 +8,7 @@ class BaseConfig(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@db/postgres'
     SECRET_KEY = Fernet.generate_key()
-    WINNERS_NUM = 3  # default: 90
+    WINNERS_NUM = 90
 
 
 class DevelopmentConfig(BaseConfig):
@@ -22,6 +22,7 @@ class TestingConfig(BaseConfig):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
     ENV = 'development'
+    WINNERS_NUM = 3 # just small value
 
 
 class PreviewDeploymentConfig(BaseConfig):

--- a/api/config.py
+++ b/api/config.py
@@ -2,7 +2,6 @@ from cryptography.fernet import Fernet
 import os
 
 
-
 class BaseConfig(object):
     DEBUG = False
     TESTING = False

--- a/api/config.py
+++ b/api/config.py
@@ -8,6 +8,7 @@ class BaseConfig(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@db/postgres'
     SECRET_KEY = Fernet.generate_key()
+    WINNERS_NUM = 3  # default: 90
 
 
 class DevelopmentConfig(BaseConfig):

--- a/api/config.py
+++ b/api/config.py
@@ -22,7 +22,7 @@ class TestingConfig(BaseConfig):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
     ENV = 'development'
-    WINNERS_NUM = 3 # just small value
+    WINNERS_NUM = 3  # just small value
 
 
 class PreviewDeploymentConfig(BaseConfig):

--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,9 @@
 from cryptography.fernet import Fernet
 import os
 
+# =========== value configs ==========
+WINNERS_NUM = 90 # default: 90
+
 
 class BaseConfig(object):
     DEBUG = False

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -179,7 +179,7 @@ def draw_lottery(idx):
         winner_apps = random.sample(
             applications, current_app.config['WINNERS_NUM'])
     except ValueError:
-        # when applications are less than WINNER_NUM, all applications are chosen
+        # if applications are less than WINNER_NUM, all applications are chosen
         winner_apps = applications
     for application in applications:
         application.status = "won" if application in winner_apps else "lose"

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -179,7 +179,7 @@ def draw_lottery(idx):
         winner_apps = random.sample(
             applications, current_app.config['WINNERS_NUM'])
     except ValueError:
-    # when applications are less than WINNER_NUM, all applications are chosen
+        # when applications are less than WINNER_NUM, all applications are chosen
         winner_apps = applications
     for application in applications:
         application.status = "won" if application in winner_apps else "lose"

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, g
 from api.models import Lottery, Classroom, User, Application, db
 from api.schemas import (
     user_schema,
+    users_schema,
     classrooms_schema,
     classroom_schema,
     application_schema,
@@ -191,8 +192,10 @@ def draw_lottery(idx):
 
     lottery.done = True
     db.session.commit()
-    winner = User.query.get(chosen.user_id)
-    result = user_schema.dump(winner)
+    winners = []
+    for chosen in chosens:
+        winners.append(User.query.get(chosen.user_id))
+    result = users_schema.dump(winners)
     return jsonify(result)
 
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -175,7 +175,7 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    try: # when applications are less than WINNER_NUM, all applications are chosen
+    try:  # when applications are less than WINNER_NUM, all applications are chosen
         winner_apps = random.sample(
             applications, current_app.config['WINNERS_NUM'])
     except ValueError:

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -178,13 +178,7 @@ def draw_lottery(idx):
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
     winner_apps = random.sample(applications, current_app.config['WINNERS_NUM'])
     for application in applications:
-        for winner_app in winner_apps:
-            if application.id == winner_app.id:
-                application.status = "won"
-                break
-            else:
-                application.status = "lose"
-
+        application.status = "won" if application in winner_apps else "lose"
         db.session.add(application)
 
     lottery.done = True

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -177,7 +177,14 @@ def draw_lottery(idx):
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
     chosens = random.sample(applications, WINNERS_NUM)
     for application in applications:
-        application.status = "won" if application.id == chosen.id else "lose"
+        for chosen in chosens:
+            if application.id == chosen.id:
+                application.status = "won"
+                chosens.remove(chosen) # remove checked ID. for performance
+                break
+            else:
+                application.status =  "lose" if application.status = "pending"
+
         db.session.add(application)
 
     lottery.done = True

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -17,7 +17,6 @@ from api.swagger import spec
 bp = Blueprint(__name__, 'api')
 
 
-
 @bp.route('/classrooms')
 @spec('api/classrooms.yml')
 def list_classrooms():
@@ -176,14 +175,16 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    winner_apps = random.sample(applications, current_app.config['WINNERS_NUM'])
+    winner_apps = random.sample(
+        applications, current_app.config['WINNERS_NUM'])
     for application in applications:
         application.status = "won" if application in winner_apps else "lose"
         db.session.add(application)
 
     lottery.done = True
     db.session.commit()
-    winners = [ User.query.get(winner_app.user_id) for winner_app in winner_apps ]
+    winners = [User.query.get(winner_app.user_id)
+               for winner_app in winner_apps]
     result = users_schema.dump(winners)
     return jsonify(result)
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -16,7 +16,7 @@ from api.swagger import spec
 bp = Blueprint(__name__, 'api')
 
 # =========== value configs ==========
-WINNERS_NUM = 90 # default: 90
+WINNERS_NUM = 3 # default: 90
 
 
 @bp.route('/classrooms')

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -175,8 +175,11 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    winner_apps = random.sample(
-        applications, current_app.config['WINNERS_NUM'])
+    try: # when applications are less than WINNER_NUM, all applications are chosen
+        winner_apps = random.sample(
+            applications, current_app.config['WINNERS_NUM'])
+    except ValueError:
+        winner_apps = applications
     for application in applications:
         application.status = "won" if application in winner_apps else "lose"
         db.session.add(application)

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -183,7 +183,7 @@ def draw_lottery(idx):
                 chosens.remove(chosen) # remove checked ID. for performance
                 break
             else:
-                application.status =  "lose" if application.status = "pending"
+                application.status =  "lose"
 
         db.session.add(application)
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -1,5 +1,5 @@
 import random
-from flask import Blueprint, jsonify, g
+from flask import Blueprint, jsonify, g, current_app
 from api.models import Lottery, Classroom, User, Application, db
 from api.schemas import (
     user_schema,
@@ -176,7 +176,7 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    winner_apps = random.sample(applications, WINNERS_NUM)
+    winner_apps = random.sample(applications, current_app.config['WINNERS_NUM'])
     for application in applications:
         for winner_app in winner_apps:
             if application.id == winner_app.id:

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -16,8 +16,6 @@ from api.swagger import spec
 
 bp = Blueprint(__name__, 'api')
 
-# =========== value configs ==========
-WINNERS_NUM = 3  # default: 90
 
 
 @bp.route('/classrooms')

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -183,7 +183,6 @@ def draw_lottery(idx):
         for winner_app in winner_apps:
             if application.id == winner_app.id:
                 application.status = "won"
-                chosens.remove(chosen) # remove checked ID. for performance
                 break
             else:
                 application.status =  "lose"

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -189,9 +189,7 @@ def draw_lottery(idx):
 
     lottery.done = True
     db.session.commit()
-    winners = []
-    for winner_app in winner_apps:
-        winners.append(User.query.get(winner_app.user_id))
+    winners = [ User.query.get(winner_app.user_id) for winner_app in winner_apps ]
     result = users_schema.dump(winners)
     return jsonify(result)
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -12,6 +12,7 @@ from api.schemas import (
 )
 from api.auth import login_required
 from api.swagger import spec
+from config import WINNERS_NUM
 
 bp = Blueprint(__name__, 'api')
 
@@ -174,7 +175,7 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    chosen = random.choice(applications)
+    chosens = random.sample(applications, WINNERS_NUM)
     for application in applications:
         application.status = "won" if application.id == chosen.id else "lose"
         db.session.add(application)

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -178,10 +178,10 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    chosens = random.sample(applications, WINNERS_NUM)
+    winner_apps = random.sample(applications, WINNERS_NUM)
     for application in applications:
-        for chosen in chosens:
-            if application.id == chosen.id:
+        for winner_app in winner_apps:
+            if application.id == winner_app.id:
                 application.status = "won"
                 chosens.remove(chosen) # remove checked ID. for performance
                 break
@@ -193,8 +193,8 @@ def draw_lottery(idx):
     lottery.done = True
     db.session.commit()
     winners = []
-    for chosen in chosens:
-        winners.append(User.query.get(chosen.user_id))
+    for winner_app in winner_apps:
+        winners.append(User.query.get(winner_app.user_id))
     result = users_schema.dump(winners)
     return jsonify(result)
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -12,9 +12,11 @@ from api.schemas import (
 )
 from api.auth import login_required
 from api.swagger import spec
-from config import WINNERS_NUM
 
 bp = Blueprint(__name__, 'api')
+
+# =========== value configs ==========
+WINNERS_NUM = 90 # default: 90
 
 
 @bp.route('/classrooms')

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -175,10 +175,11 @@ def draw_lottery(idx):
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
         return jsonify({"message": "Nobody is applying to this lottery"}), 400
-    try:  # when applications are less than WINNER_NUM, all applications are chosen
+    try:
         winner_apps = random.sample(
             applications, current_app.config['WINNERS_NUM'])
     except ValueError:
+    # when applications are less than WINNER_NUM, all applications are chosen
         winner_apps = applications
     for application in applications:
         application.status = "won" if application in winner_apps else "lose"

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -17,7 +17,7 @@ from api.swagger import spec
 bp = Blueprint(__name__, 'api')
 
 # =========== value configs ==========
-WINNERS_NUM = 3 # default: 90
+WINNERS_NUM = 3  # default: 90
 
 
 @bp.route('/classrooms')
@@ -185,7 +185,7 @@ def draw_lottery(idx):
                 application.status = "won"
                 break
             else:
-                application.status =  "lose"
+                application.status = "lose"
 
         db.session.add(application)
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -372,7 +372,7 @@ def test_draw(client):
         for user in users:
             application = Application.query.filter_by(
                 lottery=target_lottery, user_id=user.id).first()
-            status = 'won' if user.id == chosen_id else 'lose'
+            status = 'won' if user.id in chosen_id else 'lose'
             assert application.status == status
 
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -356,6 +356,9 @@ def test_draw(client):
 
         assert resp.status_code == 200
 
+        winners_id = []
+        for winner in resp.get_json()[0]:
+            winners_id.append(winner['id'])
         users = User.query.all()
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done
@@ -363,7 +366,7 @@ def test_draw(client):
             application = Application.query.filter_by(
                 lottery=target_lottery, user_id=user.id).first()
             if application:
-                status = 'won' if user.id in chosen_id else 'lose'
+                status = 'won' if user.id in winners_id else 'lose'
             assert application.status == status
 
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -337,7 +337,6 @@ def test_draw(client):
         1. make some applications to one lottery
         2. draws the lottery
         3. test: status code
-        4. test: winners are in applicant
         4. test: DB is changed
         target_url: /lotteries/<id>/apply [PUT]
     """

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -354,9 +354,7 @@ def test_draw(client):
 
         assert resp.status_code == 200
 
-        winners_id = []
-        for winner in resp.get_json()[0]:
-            winners_id.append(winner['id'])
+        winners_id = [winner['id'] for winner in resp.get_json()[0]]
         users = User.query.all()
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -13,6 +13,7 @@ from utils import (
 from api.models import Lottery, Classroom, User, Application, db
 from api.schemas import (
     user_schema,
+    users_schema,
     classrooms_schema,
     classroom_schema,
     application_schema,
@@ -357,10 +358,13 @@ def test_draw(client):
 
     chosens = resp.get_json()[0]
     with client.application.app_context():
-        user = User.query.filter_by(id=chosen_id).first()
+        chosen_ids = []
+        for chosen in chosens:
+            chosen_id = User.query.filter_by(id=chosen.id).first()
+            chosen_ids.append(chosen_id)
 
-        assert user is not None
-        assert resp.get_json()[0] == user_schema.dump(user)[0]
+        assert users is not None
+        assert resp.get_json()[0] == users_schema.dump(users)[0]
 
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -336,7 +336,8 @@ def test_draw(client):
     """attempt to draw a lottery
         1. make some applications to one lottery
         2. draws the lottery
-        3. test: status code, whether winner status is returned
+        3. test: status code
+        4. test: winners are in applicant
         4. test: DB is changed
         target_url: /lotteries/<id>/apply [PUT]
     """

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -355,7 +355,7 @@ def test_draw(client):
 
     assert resp.status_code == 200
 
-    chosen_id = resp.get_json()[0]['id']
+    chosens = resp.get_json()[0]
     with client.application.app_context():
         user = User.query.filter_by(id=chosen_id).first()
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -355,7 +355,9 @@ def test_draw(client):
             db.session.add(application)
         db.session.commit()
 
-        token = login(client, admin['username'], admin['g-recaptcha-response'])['token']
+        token = login(client,
+                      admin['username'],
+                      admin['g-recaptcha-response'])['token']
         resp = client.post('/lotteries/'+idx+'/draw',
                            headers={'Authorization': 'Bearer ' + token})
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -350,29 +350,20 @@ def test_draw(client):
             db.session.add(application)
         db.session.commit()
 
-    token = login(client, admin['username'], admin['password'])['token']
-    resp = client.post('/lotteries/'+idx+'/draw',
-                       headers={'Authorization': 'Bearer ' + token})
+        token = login(client, admin['username'], admin['password'])['token']
+        resp = client.post('/lotteries/'+idx+'/draw',
+                           headers={'Authorization': 'Bearer ' + token})
 
-    assert resp.status_code == 200
+        assert resp.status_code == 200
 
-    chosens = resp.get_json()[0]
-    with client.application.app_context():
-        chosen_ids = []
-        for chosen in chosens:
-            chosen_id = User.query.filter_by(id=chosen.id).first()
-            chosen_ids.append(chosen_id)
-
-        assert users is not None
-        assert resp.get_json()[0] == users_schema.dump(users)[0]
-
+        users = User.query.all()
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done
-        users = User.query.all()
         for user in users:
             application = Application.query.filter_by(
                 lottery=target_lottery, user_id=user.id).first()
-            status = 'won' if user.id in chosen_id else 'lose'
+            if application:
+                status = 'won' if user.id in chosen_id else 'lose'
             assert application.status == status
 
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -12,8 +12,6 @@ from utils import (
 
 from api.models import Lottery, Classroom, User, Application, db
 from api.schemas import (
-    user_schema,
-    users_schema,
     classrooms_schema,
     classroom_schema,
     application_schema,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

Step 1: 再現済み環境
====================

 * OS: Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * devenv: b2fd6c55bcfa54dcc300370dd47f20312e03aa84
 * frontend: 2ad68b9b8b2b6dc53bd93f5f5ccb909160094eb5
 * backend: 968db95e7130a3a0dcb4da41b6fcb28bc5fb45f4

Step 2: 変更内容
----------------

  * 今までは`/lotteries/{id}/draw`で1人しか当選しませんでしたが、複数人当選するようになります。
  * 当選人数: WINNERS_NUM (現状、routes/api.pyの上の方で定義されています)
  * #66

Step 2: 検証手順
================

再現のための手順:
-----------------

  1. `devenv`にて、`./scripts/start.sh`を実行し起動
  2. 何人かで一つのLotteryに応募してみる
  3. adminになって`/lottery/{id}/draw`にPOSTリクエスト
  4. Userのlistが取得できればおk

修正前の挙動:
-------------

  * 当選するのは各Lotteryあたり1人だった

修正後の挙動:
-------------

  * 複数人が当選します

Step 3: 影響範囲
================

  * 特になし