### PR TITLE
Add: Add /draw_all endpoint to draw all available lotteries

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,6 @@
 from cryptography.fernet import Fernet
 import os
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 
 class BaseConfig(object):
@@ -13,6 +13,7 @@ class BaseConfig(object):
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY')
     START_DATETIME = datetime(2018, 9, 16, 8,  40, 0)
     END_DATETIME = datetime(2018, 9, 17, 16, 00, 0)
+    DRAWING_TIME_EXTENSION = timedelta(minutes=10)
     TIMEPOINTS = [
         (time(9,  20), time(9,  50)),
         (time(10, 45), time(11, 15)),

--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,6 @@
 from cryptography.fernet import Fernet
 import os
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 
 
 class BaseConfig(object):
@@ -11,8 +11,9 @@ class BaseConfig(object):
     SECRET_KEY = Fernet.generate_key()
     WINNERS_NUM = 90
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY')
-    START_DATETIME = datetime(2018, 9, 16, 8,  40, 0)
-    END_DATETIME = datetime(2018, 9, 17, 16, 00, 0)
+    TIMEZONE = timezone(timedelta(hours=+9), 'JST')
+    START_DATETIME = datetime(2018, 9, 16, 8,  40, 0, tzinfo=TIMEZONE)
+    END_DATETIME = datetime(2018, 9, 17, 16, 00, 0, tzinfo=TIMEZONE)
     DRAWING_TIME_EXTENSION = timedelta(minutes=10)
     TIMEPOINTS = [
         (time(9,  20), time(9,  50)),

--- a/api/config.py
+++ b/api/config.py
@@ -1,5 +1,6 @@
 from cryptography.fernet import Fernet
 import os
+from datetime import datetime, time
 
 
 class BaseConfig(object):
@@ -9,6 +10,14 @@ class BaseConfig(object):
     SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@db/postgres'
     SECRET_KEY = Fernet.generate_key()
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY')
+    START_DATETIME = datetime(2018, 9, 16, 8,  40, 0)
+    END_DATETIME = datetime(2018, 9, 17, 16, 00, 0)
+    TIMEPOINTS = [
+        (time(9,  20), time(9,  50)),
+        (time(10, 45), time(11, 15)),
+        (time(12, 10), time(12, 40)),
+        (time(13, 35), time(14,  5)),
+    ]
 
 
 class DevelopmentConfig(BaseConfig):

--- a/api/draw.py
+++ b/api/draw.py
@@ -2,11 +2,13 @@ import random
 from flask import current_app
 from api.models import User, Lottery, Application, db
 
+
 class AlreadyDoneError(Exception):
     """
         The Exception that indicates the lottery has already done
     """
     pass
+
 
 class NobodyIsApplyingError(Exception):
     """

--- a/api/draw.py
+++ b/api/draw.py
@@ -2,6 +2,11 @@ import random
 from flask import current_app
 from api.models import User, Lottery, Application, db
 
+class AlreadyDoneError(Exception):
+    """
+        The Exception that indicates the lottery has already done
+    """
+    pass
 
 class NobodyIsApplyingError(Exception):
     """
@@ -18,8 +23,11 @@ def draw_one(lottery, raise_on_nobody=True):
         Return:
           winners([User]): The list of users who won
         Raises:
-            NobodyIsApplyingError
+            NobodyIsApplyingError, AlreadyDoneError
     """
+    if lottery.done:
+        raise AlreadyDoneError()
+
     idx = lottery.id
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:
@@ -53,9 +61,12 @@ def draw_all_at_index(index):
         Return:
           winners([[User]]): The list of list of users who won
         Raises:
-            NobodyIsApplyingError
+            NobodyIsApplyingError, AlreadyDoneError
     """
     lotteries = Lottery.query.filter_by(index=index)
+    if any(lottery.done for lottery in lotteries):
+        raise AlreadyDoneError()
+
     winners = [draw_one(lottery, raise_on_nobody=False)
                for lottery in lotteries]
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -58,6 +58,12 @@ def draw_all_at_index(index):
     lotteries = Lottery.query.filter_by(index=index)
     winners = [draw_one(lottery, raise_on_nobody=False)
                for lottery in lotteries]
+
+    for lottery in lotteries:
+        lottery.done = True
+        db.session.add(lottery)
+        db.session.commit()
+
     if len(winners) == 0:
         raise NobodyIsApplyingError()
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -1,0 +1,33 @@
+import random
+from flask import current_app
+from api.models import User, Application, db
+
+
+class NobodyIsApplyingError(Exception):
+    """
+        The Exception that indicates nobody is applying to the lottery
+    """
+    pass
+
+
+def draw_one(lottery):
+    idx = lottery.id
+    applications = Application.query.filter_by(lottery_id=idx).all()
+    if len(applications) == 0:
+        raise ValueError({"message": "Nobody is applying to this lottery"})
+    try:
+        winner_apps = random.sample(
+            applications, current_app.config['WINNERS_NUM'])
+    except ValueError:
+        # if applications are less than WINNER_NUM, all applications are chosen
+        winner_apps = applications
+    for application in applications:
+        application.status = "won" if application in winner_apps else "lose"
+        db.session.add(application)
+
+    lottery.done = True
+    db.session.add(lottery)
+    db.session.commit()
+    winners = [User.query.get(winner_app.user_id)
+               for winner_app in winner_apps]
+    return winners

--- a/api/draw.py
+++ b/api/draw.py
@@ -42,7 +42,7 @@ def draw_one(lottery):
     return winners
 
 
-def draw_all(index):
+def draw_all_at_index(index):
     """
         Draw all lotteries in the specific index
         Args:

--- a/api/draw.py
+++ b/api/draw.py
@@ -40,3 +40,18 @@ def draw_one(lottery):
     winners = [User.query.get(winner_app.user_id)
                for winner_app in winner_apps]
     return winners
+
+
+def draw_all(index):
+    """
+        Draw all lotteries in the specific index
+        Args:
+          index(int): zero-based index that indicates the time of lottery
+        Return:
+          winners([[User]]): The list of list of users who won
+        Raises:
+            NobodyIsApplyingError
+    """
+    lotteries = Lottery.query.filter_by(index=index)
+    winners = [draw_one(lottery) for lottery in lotteries]
+    return winners

--- a/api/draw.py
+++ b/api/draw.py
@@ -11,6 +11,15 @@ class NobodyIsApplyingError(Exception):
 
 
 def draw_one(lottery):
+    """
+        Draw the specified lottery
+        Args:
+          lottery(Lottery): The lottery to be drawn
+        Return:
+          winners([User]): The list of users who won
+        Raises:
+            NobodyIsApplyingError
+    """
     idx = lottery.id
     applications = Application.query.filter_by(lottery_id=idx).all()
     if len(applications) == 0:

--- a/api/models.py
+++ b/api/models.py
@@ -95,7 +95,7 @@ class Application(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey(
         'user.id', ondelete='CASCADE'))
     user = db.relationship('User')
-    status = db.Column(db.String)  # [ pending, won, lose ]
+    status = db.Column(db.String, default="pending", nullable=False)  # [ pending, won, lose ]
 
     def __repr__(self):
         return "<Application {}{}>".format(self.lottery, self.user)

--- a/api/models.py
+++ b/api/models.py
@@ -95,7 +95,10 @@ class Application(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey(
         'user.id', ondelete='CASCADE'))
     user = db.relationship('User')
-    status = db.Column(db.String, default="pending", nullable=False)  # [ pending, won, lose ]
+    # status: [ pending, won, lose ]
+    status = db.Column(db.String,
+                       default="pending",
+                       nullable=False)
 
     def __repr__(self):
         return "<Application {}{}>".format(self.lottery, self.user)

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -191,7 +191,7 @@ def draw_lottery(idx):
                         "and cannot be undone"}), 400
 
     result = users_schema.dump(winners)
-    return jsonify(result)
+    return jsonify(result[0])
 
 
 @bp.route('/draw_all', methods=['POST'])
@@ -217,7 +217,7 @@ def draw_all_lotteries():
 
     flattened = list(chain.from_iterable(winners))
     result = users_schema.dump(flattened)
-    return jsonify(result)
+    return jsonify(result[0])
 
 
 @bp.route('/status', methods=['GET'])

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -194,7 +194,7 @@ def draw_all_lotteries():
         # Get time index with current datetime
         index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
-        return jsonify({"message": "Not accepting"}), 400
+        return jsonify({"message": "Not acceptable time"}), 400
 
     try:
         winners = draw_all_at_index(index)

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -14,8 +14,16 @@ from api.schemas import (
 )
 from api.auth import login_required
 from api.swagger import spec
-from api.time_management import get_time_index, OutOfHoursError, OutOfAcceptingHoursError
-from api.draw import draw_one, draw_all_at_index, NobodyIsApplyingError
+from api.time_management import (
+    get_time_index,
+    OutOfHoursError,
+    OutOfAcceptingHoursError
+)
+from api.draw import (
+    draw_one,
+    draw_all_at_index,
+    NobodyIsApplyingError
+)
 
 bp = Blueprint(__name__, 'api')
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -15,7 +15,7 @@ from api.schemas import (
 from api.auth import login_required
 from api.swagger import spec
 from api.time_management import (
-    get_time_index,
+    get_draw_time_index,
     OutOfHoursError,
     OutOfAcceptingHoursError
 )
@@ -200,7 +200,7 @@ def draw_all_lotteries():
     """
     try:
         # Get time index with current datetime
-        index = get_time_index()
+        index = get_draw_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return jsonify({"message": "Not acceptable time"}), 400
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from itertools import chain
 
 from flask import Blueprint, jsonify, g
@@ -192,7 +191,8 @@ def draw_all_lotteries():
         draw all available lotteries as adminstrator
     """
     try:
-        index = get_time_index(datetime.now())
+        # Get time index with current datetime
+        index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return jsonify({"message": "Not accepting"}), 400
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -178,6 +178,16 @@ def draw_lottery(idx):
     """
         draw lottery as adminstrator
     """
+    not_accetable_resp = jsonify({"message": "Not acceptable time"})
+    try:
+        # Get time index with current datetime
+        index = get_draw_time_index()
+    except (OutOfHoursError, OutOfAcceptingHoursError):
+        return not_acceptable_resp, 400
+
+    if index != idx:
+        return not_acceptable_resp, 400
+
     lottery = Lottery.query.get(idx)
     if lottery is None:
         return jsonify({"message": "Lottery could not be found."}), 404

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -178,7 +178,7 @@ def draw_lottery(idx):
     """
         draw lottery as adminstrator
     """
-    not_accetable_resp = jsonify({"message": "Not acceptable time"})
+    not_acceptable_resp = jsonify({"message": "Not acceptable time"})
     try:
         # Get time index with current datetime
         index = get_draw_time_index()

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -178,6 +178,10 @@ def draw_lottery(idx):
     """
         draw lottery as adminstrator
     """
+    lottery = Lottery.query.get(idx)
+    if lottery is None:
+        return jsonify({"message": "Lottery could not be found."}), 404
+
     not_acceptable_resp = jsonify({"message": "Not acceptable time"})
     try:
         # Get time index with current datetime
@@ -187,10 +191,6 @@ def draw_lottery(idx):
 
     if index != idx:
         return not_acceptable_resp, 400
-
-    lottery = Lottery.query.get(idx)
-    if lottery is None:
-        return jsonify({"message": "Lottery could not be found."}), 404
 
     try:
         winners = draw_one(lottery)

--- a/api/spec/routes/api/draw_all.yml
+++ b/api/spec/routes/api/draw_all.yml
@@ -9,7 +9,7 @@ responses:
         $ref: '#/definitions/User'
       type: array
   '400':
-    description: Malformed Authenication Header has detected
+    description: Malformed Authenication Header has detected / Not acceptable time / Nobody is applying to this lottery
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':

--- a/api/spec/routes/api/draw_all.yml
+++ b/api/spec/routes/api/draw_all.yml
@@ -1,0 +1,29 @@
+Draw all of the available lotteries
+---
+parameters: []
+responses:
+  '200':
+    description: List of Users
+    schema:
+      items:
+        $ref: '#/definitions/User'
+      type: array
+  '400':
+    description: Malformed Authenication Header has detected
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+  '401':
+    description: Authorization Failed
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+  '403':
+    description: You have no permission to perform the action
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+security:
+  - admin_auth: []
+tags:
+  - lottery
+description: Draw all of the available lotteries and return the list of winners
+operationId: drawAll
+summary: Draw all of the available lotteries

--- a/api/spec/routes/api/draw_all.yml
+++ b/api/spec/routes/api/draw_all.yml
@@ -9,15 +9,27 @@ responses:
         $ref: '#/definitions/User'
       type: array
   '400':
-    description: Malformed Authenication Header has detected / Not acceptable time / Nobody is applying to this lottery
+    description: Malformed Authenication Header has detected / Not acceptable time / Nobody is applying to this lottery / This lottery has already done
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':
     description: Authorization Failed
+    headers:
+      WWW-Authenicate:
+        description: >-
+          Authenication Error Code. For details, please refer to RFC 6750
+          3. The WWW-Authenticate Response Header Field
+        type: string
     schema:
       $ref: '#/definitions/ErrorMessage'
   '403':
     description: You have no permission to perform the action
+    headers:
+      WWW-Authenicate:
+        description: >-
+          Authenication Error Code. For details, please refer to RFC 6750
+          3. The WWW-Authenticate Response Header Field
+        type: string
     schema:
       $ref: '#/definitions/ErrorMessage'
 security:

--- a/api/spec/routes/api/lotteries/draw.yml
+++ b/api/spec/routes/api/lotteries/draw.yml
@@ -15,7 +15,7 @@ responses:
     schema:
       $ref: '#/definitions/User'
   '400':
-    description: Malformed Authenication Header has detected
+    description: Malformed Authenication Header has detected / Nobody is applying to this lottery / This lottery has already done
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':

--- a/api/spec/routes/api/lotteries/draw.yml
+++ b/api/spec/routes/api/lotteries/draw.yml
@@ -15,7 +15,7 @@ responses:
     schema:
       $ref: '#/definitions/User'
   '400':
-    description: Malformed Authenication Header has detected / Nobody is applying to this lottery / This lottery has already done
+    description: Malformed Authenication Header has detected / Not acceptable time / Nobody is applying to this lottery / This lottery has already done
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -22,6 +22,8 @@ def get_time_index(time):
           time(datetime.time|datetime.datetime): The Time
         Return:
           i(int): The lottery index
+        Raises:
+          OutOfHoursError, OutOfAcceptingHoursError
     """
     if isinstance(time, datetime.datetime):
         start = current_app.config['START_DATETIME']

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -2,6 +2,22 @@ from flask import current_app
 import datetime
 
 
+def mod_time(t, dt):
+    """
+        Modify the supplied time with timedelta
+        Args:
+            t(datetime.time|datetime.datetime): The Time to modify
+            dt(datetime.timedelta): Difference
+        Returns:
+            time(datetime.time|datetime.datetime): The modified time
+    """
+    if isinstance(t, datetime.time):
+        t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
+        return (t + dt).time()
+    else:
+        return t + dt
+
+
 class OutOfHoursError(Exception):
     """
         The Exception that indicates the time was out of festival

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -69,8 +69,9 @@ def get_time_index(time=None):
     """
     time = _validate_and_get_time(time)
 
-    for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
-        if en <= time <= mod_time(en, current_app.config['DRAWING_TIME_EXTENSION']):
+    for i, (_, en) in enumerate(current_app.config['TIMEPOINTS']):
+        ext = current_app.config['DRAWING_TIME_EXTENSION']
+        if en <= time <= mod_time(en, ext):
             return i
 
     raise OutOfAcceptingHoursError()

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -45,12 +45,40 @@ def get_current_datetime():
 
 def get_time_index(time=None):
     """
-        Get the lottery index from the time
-        Args:
-          time(datetime.time|datetime.datetime): The Time
-        Return:
-          i(int): The lottery index
-        Raises:
+        get the lottery index from the drawing time
+        args:
+          time(datetime.time|datetime.datetime): the time
+        return:
+          i(int): the lottery index
+        raises:
+          OutOfHoursError, OutOfAcceptingHoursError
+    """
+    if time is None:
+        time = get_current_datetime()
+
+    if isinstance(time, datetime.datetime):
+        start = current_app.config['START_DATETIME']
+        end = current_app.config['END_DATETIME']
+        if not (start <= time <= end):
+            raise OutOfHoursError()
+        # extract datetime.time instance from datetime.datetime
+        time = time.time()
+
+    for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
+        if en <= time <= mod_time(en, current_app.config['DRAWING_TIME_EXTENSION']):
+            return i
+
+    raise OutOfAcceptingHoursError()
+
+
+def get_draw_time_index(time=None):
+    """
+        get the lottery index from the time
+        args:
+          time(datetime.time|datetime.datetime): the time
+        return:
+          i(int): the lottery index
+        raises:
           OutOfHoursError, OutOfAcceptingHoursError
     """
     if time is None:

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -8,6 +8,7 @@ class OutOfHoursError(Exception):
     """
     pass
 
+
 class OutOfAcceptingHoursError(Exception):
     """
         The Exception that indicates the time is in festival but not accepting time
@@ -15,7 +16,17 @@ class OutOfAcceptingHoursError(Exception):
     pass
 
 
-def get_time_index(time):
+def get_current_datetime():
+    """
+        Get the current datetime.
+        Note: This function is intended to be mocked in testing
+        Return:
+          time(datetime.datetime): current datetime
+    """
+    return datetime.datetime.now()
+
+
+def get_time_index(time=None):
     """
         Get the lottery index from the time
         Args:
@@ -25,6 +36,9 @@ def get_time_index(time):
         Raises:
           OutOfHoursError, OutOfAcceptingHoursError
     """
+    if time is None:
+        time = get_current_datetime()
+
     if isinstance(time, datetime.datetime):
         start = current_app.config['START_DATETIME']
         end = current_app.config['END_DATETIME']

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -40,7 +40,7 @@ def get_current_datetime():
         Return:
           time(datetime.datetime): current datetime
     """
-    return datetime.datetime.now()
+    return datetime.datetime.now(current_app.config['TIMEZONE'])
 
 
 def _validate_and_get_time(time):

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -43,6 +43,20 @@ def get_current_datetime():
     return datetime.datetime.now()
 
 
+def _validate_and_get_time(time):
+    if time is None:
+        time = get_current_datetime()
+
+    if isinstance(time, datetime.datetime):
+        start = current_app.config['START_DATETIME']
+        end = current_app.config['END_DATETIME']
+        if not (start <= time <= end):
+            raise OutOfHoursError()
+        # extract datetime.time instance from datetime.datetime
+        return time.time()
+    return time
+
+
 def get_time_index(time=None):
     """
         get the lottery index from the drawing time
@@ -53,16 +67,7 @@ def get_time_index(time=None):
         raises:
           OutOfHoursError, OutOfAcceptingHoursError
     """
-    if time is None:
-        time = get_current_datetime()
-
-    if isinstance(time, datetime.datetime):
-        start = current_app.config['START_DATETIME']
-        end = current_app.config['END_DATETIME']
-        if not (start <= time <= end):
-            raise OutOfHoursError()
-        # extract datetime.time instance from datetime.datetime
-        time = time.time()
+    time = _validate_and_get_time(time)
 
     for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
         if en <= time <= mod_time(en, current_app.config['DRAWING_TIME_EXTENSION']):
@@ -81,16 +86,7 @@ def get_draw_time_index(time=None):
         raises:
           OutOfHoursError, OutOfAcceptingHoursError
     """
-    if time is None:
-        time = get_current_datetime()
-
-    if isinstance(time, datetime.datetime):
-        start = current_app.config['START_DATETIME']
-        end = current_app.config['END_DATETIME']
-        if not (start <= time <= end):
-            raise OutOfHoursError()
-        # extract datetime.time instance from datetime.datetime
-        time = time.time()
+    time = _validate_and_get_time(time)
 
     for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
         if st <= time <= en:

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -11,7 +11,8 @@ class OutOfHoursError(Exception):
 
 class OutOfAcceptingHoursError(Exception):
     """
-        The Exception that indicates the time is in festival but not accepting time
+        The Exception that indicates the time is in festival,
+        but not in accepting time
     """
     pass
 

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -2,7 +2,7 @@ from flask import current_app
 import datetime
 
 
-class OutOfHourError(Exception):
+class OutOfHoursError(Exception):
     """
         The Exception that indicates the time was out of festival
     """

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -20,11 +20,11 @@ def get_time_index(time):
     if isinstance(time, datetime.datetime):
         start = current_app.config['START_DATETIME']
         end = current_app.config['END_DATETIME']
-        if not (start < time < end):
-            raise OutOfHourError()
+        if not (start <= time <= end):
+            raise OutOfHoursError()
         # extract datetime.time instance from datetime.datetime
         time = time.time()
 
     for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
-        if st < time < en:
+        if st <= time <= en:
             return i

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -3,10 +3,20 @@ import datetime
 
 
 class OutOfHourError(Exception):
+    """
+        The Exception that indicates the time was out of festival
+    """
     pass
 
 
 def get_time_index(time):
+    """
+        Get the lottery index from the time
+        Args:
+          time(datetime.time|datetime.datetime): The Time
+        Return:
+          i(int): The lottery index
+    """
     if isinstance(time, datetime.datetime):
         start = current_app.config['START_DATETIME']
         end = current_app.config['END_DATETIME']

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -57,7 +57,7 @@ def _validate_and_get_time(time):
     return time
 
 
-def get_time_index(time=None):
+def get_draw_time_index(time=None):
     """
         get the lottery index from the drawing time
         args:
@@ -77,7 +77,7 @@ def get_time_index(time=None):
     raise OutOfAcceptingHoursError()
 
 
-def get_draw_time_index(time=None):
+def get_time_index(time=None):
     """
         get the lottery index from the time
         args:

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -1,0 +1,16 @@
+from flask import import current_app
+import datetime
+
+class OutOfHourError(Exception):
+    pass
+
+def get_time_index(time):
+    if isinstance(time, datetime.datetime):
+        start = current_app.config['START_DATETIME']
+        end   = current_app.config['END_DATETIME']
+        if not (start < time < end):
+            raise OutOfHourError()
+
+        for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
+            if st < time < en:
+                return i

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -1,16 +1,20 @@
-from flask import import current_app
+from flask import current_app
 import datetime
+
 
 class OutOfHourError(Exception):
     pass
 
+
 def get_time_index(time):
     if isinstance(time, datetime.datetime):
         start = current_app.config['START_DATETIME']
-        end   = current_app.config['END_DATETIME']
+        end = current_app.config['END_DATETIME']
         if not (start < time < end):
             raise OutOfHourError()
+        # extract datetime.time instance from datetime.datetime
+        time = time.time()
 
-        for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
-            if st < time < en:
-                return i
+    for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
+        if st < time < en:
+            return i

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -8,6 +8,12 @@ class OutOfHoursError(Exception):
     """
     pass
 
+class OutOfAcceptingHoursError(Exception):
+    """
+        The Exception that indicates the time is in festival but not accepting time
+    """
+    pass
+
 
 def get_time_index(time):
     """
@@ -28,3 +34,5 @@ def get_time_index(time):
     for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
         if st <= time <= en:
             return i
+
+    raise OutOfAcceptingHoursError()

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -466,7 +466,7 @@ def test_draw_all(client):
         target_lotteries = Lottery.query.filter_by(index=time_index)
         non_target_lotteries = Lottery.query.filter_by(index=time_index+1)
         users = User.query.all()
-        for i, user in enumerate(users):
+        for i, user in enumerate(user for user in users if user.username != "admin"):
             target_lottery = target_lotteries[i % len(list(target_lotteries))]
             non_target_lottery = non_target_lotteries[i % len(list(non_target_lotteries))]
             application1 = Application(lottery=target_lottery, user_id=user.id)

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -366,7 +366,7 @@ def test_draw(client):
 
         assert resp.status_code == 200
 
-        winners_id = [winner['id'] for winner in resp.get_json()[0]]
+        winners_id = [winner['id'] for winner in resp.get_json()]
         users = User.query.all()
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done
@@ -489,7 +489,7 @@ def test_draw_all(client):
 
     assert resp.status_code == 200
 
-    winners_id = [winner['id'] for winner in resp.get_json()[0]]
+    winners_id = [winner['id'] for winner in resp.get_json()]
     assert all(lottery.done for lottery in target_lotteries)
     assert all(not lottery.done for lottery in non_target_lotteries)
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -9,8 +9,7 @@ from utils import (
     as_user_get,
     invalid_classroom_id,
     invalid_lottery_id,
-    make_application,
-    mod_time
+    make_application
 )
 
 from api.models import Lottery, Classroom, User, Application, db
@@ -22,6 +21,7 @@ from api.schemas import (
     lotteries_schema,
     lottery_schema
 )
+from api.time_management import mod_time
 
 
 # ---------- Lottery API
@@ -481,7 +481,7 @@ def test_draw_all(client):
     token = login(client,
                   admin['username'],
                   admin['g-recaptcha-response'])['token']
-    draw_time = client.application.config['TIMEPOINTS'][time_index][0]
+    draw_time = client.application.config['TIMEPOINTS'][time_index][1]
     with mock.patch('api.time_management.get_current_datetime',
                     return_value=draw_time):
         resp = client.post('/draw_all',
@@ -546,7 +546,8 @@ def test_draw_all_invaild(client):
     try_with_datetime(outofhours2)
 
     timepoints = client.application.config['TIMEPOINTS']
-    for i, point in enumerate(timepoints):
+    ext = client.application.config['DRAWING_TIME_EXTENSION']
+    for i, (_, en) in enumerate(timepoints):
         res = datetime.timedelta.resolution
-        try_with_datetime(mod_time(point[0], -res))
-        try_with_datetime(mod_time(point[1], +res))
+        try_with_datetime(mod_time(en, -res))
+        try_with_datetime(mod_time(en, +ext+res))

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -361,8 +361,12 @@ def test_draw(client):
         token = login(client,
                       admin['username'],
                       admin['g-recaptcha-response'])['token']
-        resp = client.post('/lotteries/'+idx+'/draw',
-                           headers={'Authorization': 'Bearer ' + token})
+
+        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        with mock.patch('api.time_management.get_current_datetime',
+                        return_value=end):
+            resp = client.post('/lotteries/'+idx+'/draw',
+                               headers={'Authorization': 'Bearer ' + token})
 
         assert resp.status_code == 200
 
@@ -458,8 +462,11 @@ def test_draw_already_done(client):
         db.session.add(target_lottery)
         db.session.commit()
 
-    resp = client.post('/lotteries/'+idx+'/draw',
-                       headers={'Authorization': 'Bearer ' + token})
+    _, end = client.application.config['TIMEPOINTS'][int(idx)]
+    with mock.patch('api.time_management.get_current_datetime',
+                    return_value=end):
+        resp = client.post('/lotteries/'+idx+'/draw',
+                           headers={'Authorization': 'Bearer ' + token})
 
     assert resp.status_code == 400
     assert 'already done' in resp.get_json()['message']

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -404,11 +404,8 @@ def test_draw_invaild(client):
     token = login(client, admin['username'],
                   admin['g-recaptcha-response'])['token']
 
-    _, end = client.application.config['TIMEPOINTS'][idx]
-    with mock.patch('api.time_management.get_current_datetime',
-                    return_value=end):
-        resp = client.post('/lotteries/'+idx+'/draw',
-                           headers={'Authorization': 'Bearer ' + token})
+    resp = client.post('/lotteries/'+idx+'/draw',
+                       headers={'Authorization': 'Bearer ' + token})
 
     assert resp.status_code == 404
     assert 'Lottery could not be found.' in resp.get_json()['message']

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -475,22 +475,23 @@ def test_draw_all(client):
             db.session.add(application2)
         db.session.commit()
 
-        token = login(client,
-                      admin['username'],
-                      admin['g-recaptcha-response'])['token']
-        draw_time = client.application.config['TIMEPOINTS'][time_index][0]
-        with mock.patch('api.time_management.get_current_datetime',
-                return_value=draw_time):
-            resp = client.post('/draw_all',
-                               headers={'Authorization': 'Bearer ' + token})
+    token = login(client,
+                  admin['username'],
+                  admin['g-recaptcha-response'])['token']
+    draw_time = client.application.config['TIMEPOINTS'][time_index][0]
+    with mock.patch('api.time_management.get_current_datetime',
+            return_value=draw_time):
+        resp = client.post('/draw_all',
+                           headers={'Authorization': 'Bearer ' + token})
 
-        assert resp.status_code == 200
+    assert resp.status_code == 200
 
-        winners_id = [winner['id'] for winner in resp.get_json()[0]]
-        assert all(lottery.done for lottery in target_lotteries)
-        assert all(not lottery.done for lottery in non_target_lotteries)
+    winners_id = [winner['id'] for winner in resp.get_json()[0]]
+    assert all(lottery.done for lottery in target_lotteries)
+    assert all(not lottery.done for lottery in non_target_lotteries)
 
-        # users = User.query.all()
+    with client.application.app_context():
+        users = User.query.all()
         for user in users:
             for lottery in target_lotteries:
                 application = Application.query.filter_by(

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -3,10 +3,57 @@ import pytest
 import datetime
 from api.time_management import (
     mod_time,
+    get_draw_time_index,
     get_time_index,
     OutOfHoursError,
     OutOfAcceptingHoursError
 )
+
+
+def test_draw_time_index_ooh(client):
+    with client.application.app_context():
+        start = client.application.config['START_DATETIME']
+        end = client.application.config['END_DATETIME']
+        res = datetime.timedelta.resolution
+        with pytest.raises(OutOfHoursError):
+            get_draw_time_index(mod_time(start, -res))
+        with pytest.raises(OutOfHoursError):
+            get_draw_time_index(mod_time(end, +res))
+
+
+def test_draw_time_index_ooa(client):
+    with client.application.app_context():
+        timepoints = client.application.config['TIMEPOINTS']
+        ext = client.application.config['DRAWING_TIME_EXTENSION']
+        for i, (_, en) in enumerate(timepoints):
+            res = datetime.timedelta.resolution
+            with pytest.raises(OutOfAcceptingHoursError):
+                get_draw_time_index(mod_time(en, -res))
+            with pytest.raises(OutOfAcceptingHoursError):
+                get_draw_time_index(mod_time(en, +ext+res))
+
+
+def test_draw_time_index_lim(client):
+    with client.application.app_context():
+        timepoints = client.application.config['TIMEPOINTS']
+        ext = client.application.config['DRAWING_TIME_EXTENSION']
+        for i, (_, en) in enumerate(timepoints):
+            res = datetime.timedelta.resolution
+            idx_l = get_draw_time_index(mod_time(en, +res))
+            assert i == idx_l
+            idx_r = get_draw_time_index(mod_time(en, +ext-res))
+            assert i == idx_r
+
+
+def test_draw_time_index_same(client):
+    with client.application.app_context():
+        timepoints = client.application.config['TIMEPOINTS']
+        ext = client.application.config['DRAWING_TIME_EXTENSION']
+        for i, (_, en) in enumerate(timepoints):
+            idx_l = get_draw_time_index(en)
+            assert i == idx_l
+            idx_r = get_draw_time_index(mod_time(en, +ext))
+            assert i == idx_r
 
 
 def test_time_index_ooh(client):

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -2,12 +2,11 @@ import pytest
 
 import datetime
 from api.time_management import (
+    mod_time,
     get_time_index,
     OutOfHoursError,
     OutOfAcceptingHoursError
 )
-
-from utils import mod_time
 
 
 def test_time_index_ooh(client):

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -1,7 +1,7 @@
 import pytest
 
 import datetime
-from api.time_management import get_time_index, OutOfHoursError
+from api.time_management import get_time_index, OutOfHoursError, OutOfAcceptingHoursError
 
 def mod_time(t, dt):
     if isinstance(t, datetime.time):
@@ -19,6 +19,16 @@ def test_time_index_ooh(client):
             get_time_index(mod_time(start, -res))
         with pytest.raises(OutOfHoursError):
             get_time_index(mod_time(end, +res))
+
+def test_time_index_ooa(client):
+    with client.application.app_context():
+        timepoints = client.application.config['TIMEPOINTS']
+        for i, point in enumerate(timepoints):
+            res = datetime.timedelta.resolution
+            with pytest.raises(OutOfAcceptingHoursError):
+                get_time_index(mod_time(point[0], -res))
+            with pytest.raises(OutOfAcceptingHoursError):
+                get_time_index(mod_time(point[1], +res))
 
 def test_time_index_lim(client):
     with client.application.app_context():

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -1,0 +1,25 @@
+import datetime
+from api.time_management import get_time_index, OutOfHoursError
+
+def test_time_index_lim(client):
+    with client.application.app_context():
+        def mod_time(t, dt):
+            datet = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
+            return (datet + dt).time()
+        timepoints = client.application.config['TIMEPOINTS']
+        for i, point in enumerate(timepoints):
+            res = datetime.timedelta.resolution
+            idx_l = get_time_index(mod_time(point[0], +res))
+            assert i == idx_l
+            idx_r = get_time_index(mod_time(point[1], -res))
+            assert i == idx_r
+
+def test_time_index_same(client):
+    with client.application.app_context():
+        timepoints = client.application.config['TIMEPOINTS']
+        for i, point in enumerate(timepoints):
+            idx_l = get_time_index(point[0])
+            assert i == idx_l
+            idx_r = get_time_index(point[1])
+            assert i == idx_r
+

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -1,9 +1,14 @@
 import pytest
 
 import datetime
-from api.time_management import get_time_index, OutOfHoursError, OutOfAcceptingHoursError
+from api.time_management import (
+    get_time_index,
+    OutOfHoursError,
+    OutOfAcceptingHoursError
+)
 
 from utils import mod_time
+
 
 def test_time_index_ooh(client):
     with client.application.app_context():

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -4,6 +4,14 @@ import datetime
 from api.time_management import get_time_index, OutOfHoursError, OutOfAcceptingHoursError
 
 def mod_time(t, dt):
+    """
+        Modify the supplied time with timedelta
+        Args:
+            t(datetime.time|datetime.datetime): The Time to modify
+            dt(datetime.timedelta): Difference
+        Returns:
+            time(datetime.time|datetime.datetime): The modified time
+    """
     if isinstance(t, datetime.time):
         t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
         return (t + dt).time()

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -1,11 +1,27 @@
+import pytest
+
 import datetime
 from api.time_management import get_time_index, OutOfHoursError
 
+def mod_time(t, dt):
+    if isinstance(t, datetime.time):
+        t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
+        return (t + dt).time()
+    else:
+        return t + dt
+
+def test_time_index_ooh(client):
+    with client.application.app_context():
+        start = client.application.config['START_DATETIME']
+        end = client.application.config['END_DATETIME']
+        res = datetime.timedelta.resolution
+        with pytest.raises(OutOfHoursError):
+            get_time_index(mod_time(start, -res))
+        with pytest.raises(OutOfHoursError):
+            get_time_index(mod_time(end, +res))
+
 def test_time_index_lim(client):
     with client.application.app_context():
-        def mod_time(t, dt):
-            datet = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
-            return (datet + dt).time()
         timepoints = client.application.config['TIMEPOINTS']
         for i, point in enumerate(timepoints):
             res = datetime.timedelta.resolution

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -3,20 +3,7 @@ import pytest
 import datetime
 from api.time_management import get_time_index, OutOfHoursError, OutOfAcceptingHoursError
 
-def mod_time(t, dt):
-    """
-        Modify the supplied time with timedelta
-        Args:
-            t(datetime.time|datetime.datetime): The Time to modify
-            dt(datetime.timedelta): Difference
-        Returns:
-            time(datetime.time|datetime.datetime): The modified time
-    """
-    if isinstance(t, datetime.time):
-        t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
-        return (t + dt).time()
-    else:
-        return t + dt
+from utils import mod_time
 
 def test_time_index_ooh(client):
     with client.application.app_context():
@@ -28,6 +15,7 @@ def test_time_index_ooh(client):
         with pytest.raises(OutOfHoursError):
             get_time_index(mod_time(end, +res))
 
+
 def test_time_index_ooa(client):
     with client.application.app_context():
         timepoints = client.application.config['TIMEPOINTS']
@@ -37,6 +25,7 @@ def test_time_index_ooa(client):
                 get_time_index(mod_time(point[0], -res))
             with pytest.raises(OutOfAcceptingHoursError):
                 get_time_index(mod_time(point[1], +res))
+
 
 def test_time_index_lim(client):
     with client.application.app_context():
@@ -48,6 +37,7 @@ def test_time_index_lim(client):
             idx_r = get_time_index(mod_time(point[1], -res))
             assert i == idx_r
 
+
 def test_time_index_same(client):
     with client.application.app_context():
         timepoints = client.application.config['TIMEPOINTS']
@@ -56,4 +46,3 @@ def test_time_index_same(client):
             assert i == idx_l
             idx_r = get_time_index(point[1])
             assert i == idx_r
-

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,3 @@
-import datetime
-
 from api.models import User, Application, db
 
 # --- variables
@@ -13,22 +11,6 @@ invalid_classroom_id = '999999999999'
 invalid_lottery_id = '9999999999'
 
 # --- methods
-
-
-def mod_time(t, dt):
-    """
-        Modify the supplied time with timedelta
-        Args:
-            t(datetime.time|datetime.datetime): The Time to modify
-            dt(datetime.timedelta): Difference
-        Returns:
-            time(datetime.time|datetime.datetime): The modified time
-    """
-    if isinstance(t, datetime.time):
-        t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
-        return (t + dt).time()
-    else:
-        return t + dt
 
 
 def login(client, username, rresp):

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,6 +13,8 @@ invalid_classroom_id = '999999999999'
 invalid_lottery_id = '9999999999'
 
 # --- methods
+
+
 def mod_time(t, dt):
     """
         Modify the supplied time with timedelta
@@ -27,6 +29,7 @@ def mod_time(t, dt):
         return (t + dt).time()
     else:
         return t + dt
+
 
 def login(client, username, rresp):
     """logging in as 'username' with 'g-recaptcha-response'

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from api.models import User, Application, db
 
 # --- variables
@@ -11,7 +13,20 @@ invalid_classroom_id = '999999999999'
 invalid_lottery_id = '9999999999'
 
 # --- methods
-
+def mod_time(t, dt):
+    """
+        Modify the supplied time with timedelta
+        Args:
+            t(datetime.time|datetime.datetime): The Time to modify
+            dt(datetime.timedelta): Difference
+        Returns:
+            time(datetime.time|datetime.datetime): The modified time
+    """
+    if isinstance(t, datetime.time):
+        t = datetime.datetime.combine(datetime.date(2000, 1, 1), t)
+        return (t + dt).time()
+    else:
+        return t + dt
 
 def login(client, username, rresp):
     """logging in as 'username' with 'g-recaptcha-response'


### PR DESCRIPTION
Step 1: 再現済み環境
====================

 * OS: Linux coordiserver 4.17.0-1-amd64 #1 SMP Debian 4.17.8-1 (2018-07-20) x86_64 GNU/Linux
 * devenv: 644a8300449c4e26134ef01d0583f7c44e4975dc
 * frontend: e2ebc7f3a73403fc2b2b71ce6e7aa1708bb6fb41
 * backend: b8acce516bc74e03b70b43f853ce656e2c2ad144
  
Step 2: 変更内容
----------------

  * `/draw_all`を追加
  * 現在時刻に基づき引くべきlotteriesを引く
    * `api.time_management`ができたりした
  * Fix #30 

Step 2: 検証手順
================

再現のための手順:
-----------------

  1. `api.config.BaseConfig`の`WINNERS_NUM`値を小さな値`2`とかに変える
  2.  `api.config.BaseConfig`の`START_DATETIME`, `END_DATETIME`, `TIMEPOINTS`をそこらへんに適当に設定する(別にマシンの時刻を変えてもいい)
  3. いくつかのユーザーで適当なlotteryにapply
  4. lotteryが引ける時間になったらadminで/draw_allをPOST
  
修正前の挙動:
-------------

  * まず/draw_allがない
  
修正後の挙動:
-------------

  * ある

Step 3: 影響範囲
================

  * `/lotteries/{idx}/draw`のフローに変更が生じたが、動作に変化はない
