### PR TITLE
Add: Add a standalone draw script

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -38,7 +38,8 @@ def home():
             recaptcha_auth = urlopen(request_uri).read()
             success = json.loads(recaptcha_auth)['success']
         else:
-            current_app.logger.warn(f'Skipping request from {request.remote_addr}')
+            current_app.logger.warn(
+                f'Skipping request from {request.remote_addr}')
             success = True
 
         if success:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request, current_app
 from urllib.request import urlopen
 import json
+from ipaddress import ip_address
 from api.models import User
 from api.auth import generate_token
 from api.swagger import spec
@@ -31,10 +32,16 @@ def home():
     recaptcha_code = data.get('g-recaptcha-response')
     user = User.query.filter_by(secret_id=secret_id).first()
     if user:
-        secret_key = current_app.config['RECAPTCHA_SECRET_KEY']
-        request_uri = f'https://www.google.com/recaptcha/api/siteverify?secret={secret_key}&response={recaptcha_code}'  # noqa: E501
-        recaptcha_auth = urlopen(request_uri).read()
-        if json.loads(recaptcha_auth)['success']:
+        if not ip_address(request.remote_addr).is_private:
+            secret_key = current_app.config['RECAPTCHA_SECRET_KEY']
+            request_uri = f'https://www.google.com/recaptcha/api/siteverify?secret={secret_key}&response={recaptcha_code}'  # noqa: E501
+            recaptcha_auth = urlopen(request_uri).read()
+            success = json.loads(recaptcha_auth)['success']
+        else:
+            current_app.logger.warn(f'Skipping request from {request.remote_addr}')
+            success = True
+
+        if success:
             token = generate_token({'user_id': user.id})
             return jsonify({"message": "Login Successful",
                             "token": token.decode()})

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -30,7 +30,6 @@ with open(args.list, 'r') as f:
 # Take one 'admin' user from list
 admin_ids = next(cred for cred in id_list if cred['authority'] == 'admin')
 
-
 def post_json(url, data=None, token=None):
     headers = {"Content-Type": "application/json"}
     if token:
@@ -63,7 +62,7 @@ if not args.yes:
     print('Proceed? [ny] >', end='')
     ans = input()
     if ans != 'y':
-        print('Abort.')
+        print('Abort.', file=sys.stderr)
         sys.exit(-1)
 
 # POST /draw_all

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -6,8 +6,12 @@
 # Also this is intended to be run not in virtualenv
 # but in systemd-timer or cron, etc...
 
-import json
 import sys
+
+if sys.version_info[0] < 3:
+    raise Exception("Must be using Python 3")
+
+import json
 import argparse
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -10,6 +10,7 @@ import json
 import sys
 import argparse
 from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 
 parser = argparse.ArgumentParser(
     description='Draw currently available lotteries')
@@ -37,9 +38,15 @@ def post_json(url, data=None, token=None):
     json_data = json.dumps(data).encode("utf-8") if data else None
     request = Request(f'{args.protocol}://{args.host}/{url}', data=json_data,
                       headers=headers, method='POST')
-    with urlopen(request) as response:
+    try:
+        response = urlopen(request)
+    except HTTPError as e:
+        print(f'Error: {e.read()}', file=sys.stderr)
+        sys.exit(-1)
+    else:
         response_body = response.read().decode("utf-8")
-    return json.loads(response_body)
+        response.close()
+        return json.loads(response_body)
 
 
 # Login as admin

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -7,10 +7,10 @@
 # but in systemd-timer or cron, etc...
 
 import json
-from urllib.request import Request
+from urllib.request import Request, urlopen
 
-ID_LIST_PATH=""
-API_HOST=""
+ID_LIST_PATH = ""
+API_HOST = ""
 
 id_list = json.load()
 
@@ -20,15 +20,18 @@ admin_cred = next(cred for cred in id_list if cred['authority'] == 'admin')
 # exclude 'authority' key & value from credential
 admin_cred = {k: v for k, v in admin_cred.items() if k != 'authority'}
 
+
 def post_json(url, data=None, token=None):
     headers = {"Content-Type": "application/json"}
     if token:
         headers['Authorization'] = f'Bearer {token}'
     json_data = json.dumps(data).encode("utf-8") if data else None
-    request = Request(f'{API_HOST}/{url}', data=json_data, headers=headers, method='POST')
+    request = Request(f'{API_HOST}/{url}', data=json_data,
+                      headers=headers, method='POST')
     with urlopen(request) as response:
         response_body = response.read().decode("utf-8")
     return json.loads(response_body)
+
 
 # Login as admin
 response = post_json('/auth', admin_cred)

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(
     description='Draw currently available lotteries')
 parser.add_argument("-l", "--list", type=str,
                     required=True, help="ID list json file path")
-parser.add_argument("-h", "--host", type=str,
+parser.add_argument("-a", "--host", type=str,
                     default="localhost", help="API hostname")
 parser.add_argument("-y", "--yes", action='store_true',
                     help="Don't confirm before drawing")

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -7,12 +7,18 @@
 # but in systemd-timer or cron, etc...
 
 import json
+import argparse
 from urllib.request import Request, urlopen
 
-ID_LIST_PATH = ""
-API_HOST = ""
+parser = argparse.ArgumentParser(
+    description='Draw currently available lotteries')
+parser.add_argument("-l", "--list", type=str,
+                    required=True, help="ID list json file path")
+parser.add_argument("-h", "--host", type=str,
+                    default="localhost", help="API hostname")
+args = parser.parse_args()
 
-with open(ID_LIST_PATH, 'r') as f:
+with open(args.list, 'r') as f:
     id_list = json.load(f)
 
 # Take one 'admin' user from list
@@ -27,7 +33,7 @@ def post_json(url, data=None, token=None):
     if token:
         headers['Authorization'] = f'Bearer {token}'
     json_data = json.dumps(data).encode("utf-8") if data else None
-    request = Request(f'{API_HOST}/{url}', data=json_data,
+    request = Request(f'{args.host}/{url}', data=json_data,
                       headers=headers, method='POST')
     with urlopen(request) as response:
         response_body = response.read().decode("utf-8")

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -6,12 +6,8 @@
 # Also this is intended to be run not in virtualenv
 # but in systemd-timer or cron, etc...
 
-import sys
-
-if sys.version_info[0] < 3:
-    raise Exception("Must be using Python 3")
-
 import json
+import sys
 import argparse
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -30,12 +30,14 @@ with open(args.list, 'r') as f:
 # Take one 'admin' user from list
 admin_ids = next(cred for cred in id_list if cred['authority'] == 'admin')
 
-def post_json(url, data=None, token=None):
+
+def post_json(path, data=None, token=None):
     headers = {"Content-Type": "application/json"}
     if token:
         headers['Authorization'] = 'Bearer ' + token
     json_data = json.dumps(data).encode("utf-8") if data else None
-    request = Request('{}://{}/{}'.format(args.protocol, args.host, url), data=json_data,
+    url = '{}://{}/{}'.format(args.protocol, args.host, path)
+    request = Request(url, data=json_data,
                       headers=headers, method='POST')
     try:
         response = urlopen(request)

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -1,0 +1,41 @@
+#
+# draw script
+#
+# This script is standalone, which is not depends on
+# any other modules in this project
+# Also this is intended to be run not in virtualenv
+# but in systemd-timer or cron, etc...
+
+import json
+from urllib.request import Request
+
+ID_LIST_PATH=""
+API_HOST=""
+
+id_list = json.load()
+
+# Take one 'admin' user from list
+admin_cred = next(cred for cred in id_list if cred['authority'] == 'admin')
+
+# exclude 'authority' key & value from credential
+admin_cred = {k: v for k, v in admin_cred.items() if k != 'authority'}
+
+def post_json(url, data=None, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+    json_data = json.dumps(data).encode("utf-8") if data else None
+    request = Request(f'{API_HOST}/{url}', data=json_data, headers=headers, method='POST')
+    with urlopen(request) as response:
+        response_body = response.read().decode("utf-8")
+    return json.loads(response_body)
+
+# Login as admin
+response = post_json('/auth', admin_cred)
+token = response['token']
+
+# POST /draw_all
+response_draw = post_json('/draw_all', None, token)
+
+# Print the result
+print(response_draw)

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -12,7 +12,8 @@ from urllib.request import Request, urlopen
 ID_LIST_PATH = ""
 API_HOST = ""
 
-id_list = json.load()
+with open(ID_LIST_PATH, 'r') as f:
+    id_list = json.load(f)
 
 # Take one 'admin' user from list
 admin_cred = next(cred for cred in id_list if cred['authority'] == 'admin')

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -29,6 +29,7 @@ with open(args.list, 'r') as f:
 # Take one 'admin' user from list
 admin_ids = next(cred for cred in id_list if cred['authority'] == 'admin')
 
+
 def post_json(url, data=None, token=None):
     headers = {"Content-Type": "application/json"}
     if token:

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -33,14 +33,14 @@ admin_ids = next(cred for cred in id_list if cred['authority'] == 'admin')
 def post_json(url, data=None, token=None):
     headers = {"Content-Type": "application/json"}
     if token:
-        headers['Authorization'] = f'Bearer {token}'
+        headers['Authorization'] = 'Bearer ' + token
     json_data = json.dumps(data).encode("utf-8") if data else None
-    request = Request(f'{args.protocol}://{args.host}/{url}', data=json_data,
+    request = Request('{}://{}/{}'.format(args.protocol, args.host, url), data=json_data,
                       headers=headers, method='POST')
     try:
         response = urlopen(request)
     except HTTPError as e:
-        print(f'Error: {e.read()}', file=sys.stderr)
+        print('Error: {}'.format(e.read()), file=sys.stderr)
         sys.exit(-1)
     else:
         response_body = response.read().decode("utf-8")

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -27,11 +27,7 @@ with open(args.list, 'r') as f:
     id_list = json.load(f)
 
 # Take one 'admin' user from list
-admin_cred = next(cred for cred in id_list if cred['authority'] == 'admin')
-
-# exclude 'authority' key & value from credential
-admin_cred = {k: v for k, v in admin_cred.items() if k != 'authority'}
-
+admin_ids = next(cred for cred in id_list if cred['authority'] == 'admin')
 
 def post_json(url, data=None, token=None):
     headers = {"Content-Type": "application/json"}
@@ -46,6 +42,11 @@ def post_json(url, data=None, token=None):
 
 
 # Login as admin
+admin_cred = {
+    'id': admin_ids['secret_id'],
+    'g-recaptcha-response': ''
+}
+
 response = post_json('auth', admin_cred)
 token = response['token']
 

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -17,6 +17,8 @@ parser.add_argument("-l", "--list", type=str,
                     required=True, help="ID list json file path")
 parser.add_argument("-a", "--host", type=str,
                     default="localhost", help="API hostname")
+parser.add_argument("-p", "--protocol", type=str,
+                    default="http", help="The protocol to use")
 parser.add_argument("-y", "--yes", action='store_true',
                     help="Don't confirm before drawing")
 args = parser.parse_args()
@@ -36,7 +38,7 @@ def post_json(url, data=None, token=None):
     if token:
         headers['Authorization'] = f'Bearer {token}'
     json_data = json.dumps(data).encode("utf-8") if data else None
-    request = Request(f'{args.host}/{url}', data=json_data,
+    request = Request(f'{args.protocol}://{args.host}/{url}', data=json_data,
                       headers=headers, method='POST')
     with urlopen(request) as response:
         response_body = response.read().decode("utf-8")
@@ -44,7 +46,7 @@ def post_json(url, data=None, token=None):
 
 
 # Login as admin
-response = post_json('/auth', admin_cred)
+response = post_json('auth', admin_cred)
 token = response['token']
 
 if not args.yes:
@@ -56,7 +58,7 @@ if not args.yes:
         sys.exit(-1)
 
 # POST /draw_all
-response_draw = post_json('/draw_all', None, token)
+response_draw = post_json('draw_all', None, token)
 
 # Print the result
 print(response_draw)

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -7,6 +7,7 @@
 # but in systemd-timer or cron, etc...
 
 import json
+import sys
 import argparse
 from urllib.request import Request, urlopen
 
@@ -16,6 +17,8 @@ parser.add_argument("-l", "--list", type=str,
                     required=True, help="ID list json file path")
 parser.add_argument("-h", "--host", type=str,
                     default="localhost", help="API hostname")
+parser.add_argument("-y", "--yes", action='store_true',
+                    help="Don't confirm before drawing")
 args = parser.parse_args()
 
 with open(args.list, 'r') as f:
@@ -43,6 +46,14 @@ def post_json(url, data=None, token=None):
 # Login as admin
 response = post_json('/auth', admin_cred)
 token = response['token']
+
+if not args.yes:
+    print('Attempt to draw lotteries.')
+    print('Proceed? [ny] >', end='')
+    ans = input()
+    if ans != 'y':
+        print('Abort.')
+        sys.exit(-1)
 
 # POST /draw_all
 response_draw = post_json('/draw_all', None, token)


### PR DESCRIPTION
Step 1: 再現済み環境
====================

 * OS: Linux coordiserver 4.17.0-1-amd64#1 SMP Debian 4.17.8-1 (2018-07-20) x86_64 GNU/Linux
 * devenv: 79794c5c4135b4cea08e5f3644368f15ddcbb6b4
 * frontend: 605f436b125664e736b7519b83b5483fd387296d
 * backend: 5118c5245e3da30523cdca421815afa6d146571a
  
Step 2: 変更内容
----------------

  * スタンドアロンな、`draw.py`スクリプトを作成
  * Python3の処理系があればvirtualenv外で実行できる→systemd-timerやcronで実行可能
  * また`admin`の自動認証がきつい為プライベートIPからのアクセスにはreCAPTCHAをやらないようにした

Step 2: 検証手順
================

再現のための手順:
-----------------

  1. `python3 scripts/draw.py -l {jsonへのパス}`
  
修正前の挙動:
-------------

  * `draw.py`がない
  
修正後の挙動:
-------------

  * ある。

Step 3: 影響範囲
================

  * ない
