### PR TITLE
抽選に応募できる時間を制限する-#1

### DIFF
--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -104,10 +104,10 @@ def apply_lottery(idx):
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return jsonify({"message":
                         "We're not accepting any application in this hours."}
-                       ), 403
+                       ), 400
     if lottery.index != current_index:
         return jsonify({"message":
-                        "This lottery is not acceptable now."}), 403
+                        "This lottery is not acceptable now."}), 400
     user = User.query.filter_by(id=g.token_data['user_id']).first()
     previous = Application.query.filter_by(user_id=user.id)
     if any(app.lottery.index == lottery.index and

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -99,14 +99,14 @@ def apply_lottery(idx):
         return jsonify({"message": "Lottery could not be found."}), 404
     if lottery.done:
         return jsonify({"message": "This lottery has already done"}), 400
-    cant_apply_resp = jsonify({"message":
-                               "you can't apply to this lottery"})
     try:
         current_index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
-        return cant_apply_resp, 403
+        return jsonify({"message":
+                        "No lotteries are supplied"}), 403
     if lottery.index != current_index:
-        return cant_apply_resp, 403
+        return jsonify({"message":
+                        "you can't apply to this lottery"}), 403
     user = User.query.filter_by(id=g.token_data['user_id']).first()
     previous = Application.query.filter_by(user_id=user.id)
     if any(app.lottery.index == lottery.index and

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -103,10 +103,11 @@ def apply_lottery(idx):
         current_index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return jsonify({"message":
-                        "No lotteries are supplied"}), 403
+                        "We're not accepting any application in this hours."}
+                       ), 403
     if lottery.index != current_index:
         return jsonify({"message":
-                        "you can't apply to this lottery"}), 403
+                        "This lottery is not acceptable now."}), 403
     user = User.query.filter_by(id=g.token_data['user_id']).first()
     previous = Application.query.filter_by(user_id=user.id)
     if any(app.lottery.index == lottery.index and

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -99,10 +99,14 @@ def apply_lottery(idx):
         return jsonify({"message": "Lottery could not be found."}), 404
     if lottery.done:
         return jsonify({"message": "This lottery has already done"}), 400
-    current_index = get_time_index()
+    cant_apply_resp = jsonify({"message":
+                               "you can't apply to this lottery"})
+    try:
+        current_index = get_time_index()
+    except (OutOfHoursError, OutOfAcceptingHoursError):
+        return cant_apply_resp, 403
     if lottery.index != current_index:
-        return jsonify({"message":
-                        "You have no permission to perform the action"}), 403
+        return cant_apply_resp, 403
     user = User.query.filter_by(id=g.token_data['user_id']).first()
     previous = Application.query.filter_by(user_id=user.id)
     if any(app.lottery.index == lottery.index and

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -17,7 +17,8 @@ from api.swagger import spec
 from api.time_management import (
     get_draw_time_index,
     OutOfHoursError,
-    OutOfAcceptingHoursError
+    OutOfAcceptingHoursError,
+    get_time_index
 )
 from api.draw import (
     draw_one,
@@ -98,6 +99,10 @@ def apply_lottery(idx):
         return jsonify({"message": "Lottery could not be found."}), 404
     if lottery.done:
         return jsonify({"message": "This lottery has already done"}), 400
+    current_index = get_time_index()
+    if lottery.index != current_index:
+        return jsonify({"message":
+                        "You have no permission to perform the action"}), 403
     user = User.query.filter_by(id=g.token_data['user_id']).first()
     previous = Application.query.filter_by(user_id=user.id)
     if any(app.lottery.index == lottery.index and

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -37,7 +37,7 @@ responses:
     schema:
       $ref: '#/definitions/ErrorMessage'
   '403':
-    description: You have no permission to perform the action / you can't apply to this lottery / No lotteries are supplied
+    description: You have no permission to perform the action / We're not accepting any application in this hours. / this lottery is not acceptable now.
     headers:
       WWW-Authenicate:
         description: >-

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -37,7 +37,7 @@ responses:
     schema:
       $ref: '#/definitions/ErrorMessage'
   '403':
-    description: You have no permission to perform the action
+    description: You have no permission to perform the action / you can't apply to this lottery / No lotteries are supplied
     headers:
       WWW-Authenicate:
         description: >-

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -18,6 +18,8 @@ responses:
     description: >-
       Malformed Authenication Header has detected / Lottery has already
       done / You’re already applying to a lottery in this period
+      / We're not accepting any application in this hours.
+      / this lottery is not acceptable now.
     headers:
       WWW-Authenicate:
         description: >-
@@ -37,7 +39,7 @@ responses:
     schema:
       $ref: '#/definitions/ErrorMessage'
   '403':
-    description: You have no permission to perform the action / We're not accepting any application in this hours. / this lottery is not acceptable now.
+    description: You have no permission to perform the action
     headers:
       WWW-Authenicate:
         description: >-

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -212,6 +212,22 @@ def test_apply_same_period(client):
     assert 'already applying to a lottery in this period' in message
 
 
+def test_apply_time_invalid(client):
+    """attempt to apply to lottery out of range
+        target_url: /lotteries/<id> [POST]
+    """
+    idx = '1'
+    token = login(client, test_user['secret_id'],
+                  test_user['g-recaptcha-response'])['token']
+
+    with mock.patch('api.routes.api.get_time_index',
+                    return_value=1):
+        resp = client.post(f'/lotteries/{idx}',
+                           headers={'Authorization': f'Bearer {token}'})
+        assert resp.status_code == 403
+        assert "you can't apply to this lottery" in resp.get_json()['message']
+
+
 def test_get_allapplications(client):
     """test proper infomation is returned from the API
         target_url: /applications

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -222,8 +222,9 @@ def test_apply_time_invalid(client):
     token = login(client, test_user['secret_id'],
                   test_user['g-recaptcha-response'])['token']
 
+    index = Lottery.query.get(idx).index
     with mock.patch('api.routes.api.get_time_index',
-                    return_value=1):
+                    return_value=index + 1):
         resp = client.post(f'/lotteries/{idx}',
                            headers={'Authorization': f'Bearer {token}'})
         assert resp.status_code == 403

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -228,8 +228,9 @@ def test_apply_time_invalid(client):
                     return_value=index + 1):
         resp = client.post(f'/lotteries/{idx}',
                            headers={'Authorization': f'Bearer {token}'})
-        assert resp.status_code == 403
-        assert "you can't apply to this lottery" in resp.get_json()['message']
+        assert resp.status_code == 400
+        assert "this lottery is not acceptable now." in \
+               resp.get_json()['message']
 
 
 def test_get_allapplications(client):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -111,8 +111,9 @@ def test_apply(client):
         target_url: /lotteries/<id> [POST]
     """
     idx = '1'
-    token = login(client, test_user['secret_id'],
-                  test_user['g-recaptcha-response'])['token']
+    user_info = test_user
+    token = login(client, user_info['secret_id'],
+                  user_info['g-recaptcha-response'])['token']
     with client.application.app_context():
         lottery = Lottery.query.get(idx)
     with mock.patch('api.routes.api.get_time_index',
@@ -124,7 +125,7 @@ def test_apply(client):
     with client.application.app_context():
         # get needed objects
         target_lottery = Lottery.query.filter_by(id=idx).first()
-        user = User.query.filter_by(secret_id=test_user['secret_id']).first()
+        user = User.query.filter_by(secret_id=user_info['secret_id']).first()
         # this application should be added by previous 'client.put'
         application = Application.query.filter_by(
             lottery=target_lottery, user_id=user.id).first()

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -229,7 +229,7 @@ def test_apply_time_invalid(client):
         resp = client.post(f'/lotteries/{idx}',
                            headers={'Authorization': f'Bearer {token}'})
         assert resp.status_code == 400
-        assert "this lottery is not acceptable now." in \
+        assert "This lottery is not acceptable now." in \
                resp.get_json()['message']
 
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -117,8 +117,8 @@ def test_apply(client):
     with client.application.app_context():
         _, time = current_app.config['TIMEPOINTS'][0]
         apply_date = mod_time(time, datetime.timedelta.resolution)
-    with mock.patch('api.time_management.get_time_index',
                     return_value=idx):
+    with mock.patch('api.routes.api.get_time_index',
         resp = client.post('/lotteries/'+idx,
                            headers={'Authorization': 'Bearer ' + token})
         assert resp.status_code == 200

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -1,4 +1,3 @@
-from flask import current_app
 from unittest import mock
 import pytest
 import datetime
@@ -115,8 +114,6 @@ def test_apply(client):
     token = login(client, test_user['secret_id'],
                   test_user['g-recaptcha-response'])['token']
     with client.application.app_context():
-        _, time = current_app.config['TIMEPOINTS'][0]
-        apply_date = mod_time(time, datetime.timedelta.resolution)
         lottery = Lottery.query.get(idx)
     with mock.patch('api.routes.api.get_time_index',
                     return_value=lottery.index):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -203,8 +203,10 @@ def test_apply_same_period(client):
         db.session.add(application)
         db.session.commit()
 
-    resp = client.post('/lotteries/'+idx,
-                       headers={'Authorization': 'Bearer ' + token})
+    with mock.patch('api.routes.api.get_time_index',
+                    return_value=0):
+        resp = client.post('/lotteries/'+idx,
+                           headers={'Authorization': 'Bearer ' + token})
 
     message = resp.get_json()['message']
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -117,8 +117,9 @@ def test_apply(client):
     with client.application.app_context():
         _, time = current_app.config['TIMEPOINTS'][0]
         apply_date = mod_time(time, datetime.timedelta.resolution)
-                    return_value=idx):
+        lottery = Lottery.query.get(idx)
     with mock.patch('api.routes.api.get_time_index',
+                    return_value=lottery.index):
         resp = client.post('/lotteries/'+idx,
                            headers={'Authorization': 'Bearer ' + token})
         assert resp.status_code == 200

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -218,7 +218,7 @@ def test_apply_time_invalid(client):
     """attempt to apply to lottery out of range
         target_url: /lotteries/<id> [POST]
     """
-    idx = '1'
+    idx = 1
     token = login(client, test_user['secret_id'],
                   test_user['g-recaptcha-response'])['token']
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -110,7 +110,7 @@ def test_apply(client):
         2. test: DB is changed
         target_url: /lotteries/<id> [POST]
     """
-    idx = '1'
+    idx = 1
     user_info = test_user
     token = login(client, user_info['secret_id'],
                   user_info['g-recaptcha-response'])['token']
@@ -118,8 +118,8 @@ def test_apply(client):
         lottery = Lottery.query.get(idx)
     with mock.patch('api.routes.api.get_time_index',
                     return_value=lottery.index):
-        resp = client.post('/lotteries/'+idx,
-                           headers={'Authorization': 'Bearer ' + token})
+        resp = client.post(f'/lotteries/{idx}',
+                           headers={'Authorization': f'Bearer {token}'})
         assert resp.status_code == 200
 
     with client.application.app_context():
@@ -190,7 +190,7 @@ def test_apply_same_period(client):
         1. test: error is returned
         target_url: /lotteries/<id> [POST]
     """
-    idx = '1'
+    idx = 1
     token = login(client, test_user['secret_id'],
                   test_user['g-recaptcha-response'])['token']
 
@@ -205,8 +205,8 @@ def test_apply_same_period(client):
 
     with mock.patch('api.routes.api.get_time_index',
                     return_value=0):
-        resp = client.post('/lotteries/'+idx,
-                           headers={'Authorization': 'Bearer ' + token})
+        resp = client.post(f'/lotteries/{idx}',
+                           headers={'Authorization': f'Bearer {token}'})
 
     message = resp.get_json()['message']
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -222,7 +222,8 @@ def test_apply_time_invalid(client):
     token = login(client, test_user['secret_id'],
                   test_user['g-recaptcha-response'])['token']
 
-    index = Lottery.query.get(idx).index
+    with client.application.app_context():
+        index = Lottery.query.get(idx).index
     with mock.patch('api.routes.api.get_time_index',
                     return_value=index + 1):
         resp = client.post(f'/lotteries/{idx}',


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

Step 1: 再現済み環境
====================

 * OS: Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0:
Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * devenv: b2fd6c55bcfa54dcc300370dd47f20312e03aa84
 * frontend: 2ad68b9b8b2b6dc53bd93f5f5ccb909160094eb5
 * backend: 6444ca4e6f883d1f8c604547ffdf8bfc9cb6f444

Step 2: 変更内容
----------------

  * 各抽選に応募できる時間帯を制限します。
  * 具体的には、`api/config.py`内にある`TIMEPOINTS`の範囲内の時のみ応募が可能になります。
  * 追加されるHTTPステータスコードは以下の通りです
    * 403 --- 創作展外の時間帯の時・要求された抽選の応募可能時間外の時
  * 参照: #1 - 次回公演のみ応募可能にする

Step 2: 検証手順
================

再現のための手順:
-----------------

人力検証が必要な部分はありません。
差分のあるテストコードのみ確認お願いします。

修正前の挙動:
-------------

  * 創作展期間中ならば、どんな時間帯でも全ての（まだ終わっていない）抽選に応募できた

修正後の挙動:
-------------

  * 各抽選に設定された時間ないのみでしか応募できなくなった

Step 3: 影響範囲
================

  * ありません。