### PR TITLE
Feature/68 applications auth

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -40,7 +40,10 @@ def decrypt_token(token):
     return json.loads(decrypted.decode())
 
 
-def login_required(required_authority=None):
+all_authorities = ["", "admin"]     # all possible kinds of authorities
+
+
+def login_required(required_authority=all_authorities):
     """
         a decorder to require login
     """
@@ -81,8 +84,7 @@ def login_required(required_authority=None):
             if not data:
                 return auth_error(401, 'error="invalid_token"')
             user = User.query.filter_by(id=data['data']['user_id']).first()
-            if required_authority is not None \
-                    and user.authority != required_authority:
+            if user.authority not in required_authority:
                 return auth_error(403, 'error="insufficient_scope"')
             g.token_data = data['data']
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -40,10 +40,7 @@ def decrypt_token(token):
     return json.loads(decrypted.decode())
 
 
-all_authorities = ["", "admin"]     # all possible kinds of authorities
-
-
-def login_required(required_authority=all_authorities):
+def login_required(*required_authority):
     """
         a decorder to require login
     """
@@ -84,7 +81,8 @@ def login_required(required_authority=all_authorities):
             if not data:
                 return auth_error(401, 'error="invalid_token"')
             user = User.query.filter_by(id=data['data']['user_id']).first()
-            if user.authority not in required_authority:
+            if required_authority and \
+                    (user.authority not in required_authority):
                 return auth_error(403, 'error="insufficient_scope"')
             g.token_data = data['data']
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -120,7 +120,7 @@ def apply_lottery(idx):
 
 @bp.route('/applications')
 @spec('api/applications.yml')
-@login_required()
+@login_required("admin")
 def list_applications():
     """
         return applications list.
@@ -137,7 +137,7 @@ def list_applications():
 
 @bp.route('/applications/<int:idx>', methods=['GET'])
 @spec('api/applications/idx.yml')
-@login_required()
+@login_required("admin")
 def list_application(idx):
     """
         return infomation about specified application.
@@ -153,7 +153,7 @@ def list_application(idx):
 
 @bp.route('/applications/<int:idx>', methods=['DELETE'])
 @spec('api/applications/cancel.yml')
-@login_required()
+@login_required("admin")
 def cancel_application(idx):
     """
         cancel the application.

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -120,7 +120,7 @@ def apply_lottery(idx):
 
 @bp.route('/applications')
 @spec('api/applications.yml')
-@login_required("admin")
+@login_required('admin', 'staff')
 def list_applications():
     """
         return applications list.
@@ -137,7 +137,7 @@ def list_applications():
 
 @bp.route('/applications/<int:idx>', methods=['GET'])
 @spec('api/applications/idx.yml')
-@login_required("admin")
+@login_required('admin', 'staff')
 def list_application(idx):
     """
         return infomation about specified application.
@@ -153,7 +153,7 @@ def list_application(idx):
 
 @bp.route('/applications/<int:idx>', methods=['DELETE'])
 @spec('api/applications/cancel.yml')
-@login_required("admin")
+@login_required('admin', 'staff')
 def cancel_application(idx):
     """
         cancel the application.


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

Step 1: 再現済み環境
====================

 * OS: Linux masato-laptop 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * devenv: 430fe0b0414b51beff2e40176899c2a5d494dc3c
 * frontend: ada3edcf5dde75e1c4843140165d7dbe9efd6db3
 * backend: 7e02b7d2d438fd023b1d87036a18d76cb287134a

  
Step 2: 変更内容
----------------

Fix: #68 

Step 2: 検証手順
================

再現のための手順:
-----------------

admin、staffでないtokenで
`applications/`にGET、`applications/{id}`にGET・DELETE
（staffは一応友人受付のことを考えて許可したauthorityだが
　まだ追加されてないので今のところ関係ない）
  
修正前の挙動:
-------------

普通に処理
  
修正後の挙動:
-------------

admin、staff以外のtokenによるアクセスに対し
message: `403 Forbidden`を返す
（staffは一応友人受付のことを考えて許可したauthorityだが
　まだ追加されてないので今のところ関係ない）
 
Step 3: 影響範囲
================

 私には思い当たらない…
