### PR TITLE
"normal" authorityの追加

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -43,6 +43,9 @@ def decrypt_token(token):
 def login_required(*required_authority):
     """
         a decorder to require login
+        Args:
+            *required_authority (str): required authorities
+                if this is blank, no requirement of authority
     """
     def login_required_impl(f):
         @wraps(f)

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -86,7 +86,7 @@ def list_lottery(idx):
 
 @bp.route('/lotteries/<int:idx>', methods=['POST'])
 @spec('api/lotteries/apply.yml')
-@login_required('')
+@login_required('normal')
 def apply_lottery(idx):
     """
         apply to the lottery.
@@ -120,7 +120,7 @@ def apply_lottery(idx):
 
 @bp.route('/applications')
 @spec('api/applications.yml')
-@login_required('')
+@login_required('normal')
 def list_applications():
     """
         return applications list.
@@ -137,7 +137,7 @@ def list_applications():
 
 @bp.route('/applications/<int:idx>', methods=['GET'])
 @spec('api/applications/idx.yml')
-@login_required('')
+@login_required('normal')
 def list_application(idx):
     """
         return infomation about specified application.
@@ -153,7 +153,7 @@ def list_application(idx):
 
 @bp.route('/applications/<int:idx>', methods=['DELETE'])
 @spec('api/applications/cancel.yml')
-@login_required('')
+@login_required('normal')
 def cancel_application(idx):
     """
         cancel the application.
@@ -227,7 +227,7 @@ def draw_all_lotteries():
 
 @bp.route('/status', methods=['GET'])
 @spec('api/status.yml')
-@login_required('')
+@login_required('normal')
 def get_status():
     """
         return user's id and applications

--- a/cards/id.py
+++ b/cards/id.py
@@ -97,7 +97,7 @@ def generate_ids(how_many):
     id_dicts = [{
                 "secret_id": secret,
                 "public_id": encode_public_id(public),
-                "authority": "normal"
+                "authority": "normal"   # normal user (not admin or staff)
                 }
                 for (secret, public) in zip(secret_ids, public_raw_ids)]
 

--- a/cards/id.py
+++ b/cards/id.py
@@ -97,7 +97,7 @@ def generate_ids(how_many):
     id_dicts = [{
                 "secret_id": secret,
                 "public_id": encode_public_id(public),
-                "authority": ""
+                "authority": "normal"
                 }
                 for (secret, public) in zip(secret_ids, public_raw_ids)]
 

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -1,57 +1,57 @@
 [
     {
-        "secret_id": "6jt8DtRpI8jqxH2SVoNKNH_81Fuhmz4n",
-        "public_id": "7HME",
-        "authority": ""
+        "secret_id": "nCGX_hMrMZxRAak-W36kIzzxrup_SIKI",
+        "public_id": "6YGW",
+        "authority": "normal"
     },
     {
-        "secret_id": "Ap_pFbQ7UE7LTaJdCzh5IcwptKzsWTs7",
-        "public_id": "3FRT",
-        "authority": ""
+        "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
+        "public_id": "5RAX",
+        "authority": "normal"
     },
     {
-        "secret_id": "RBiBL9HKAyaCA4Dk2vQKQ6u-YHxkJKvE",
-        "public_id": "5KHE",
-        "authority": ""
+        "secret_id": "zmPplhO29m7dMNDdLnt4MtO_aFONrViC",
+        "public_id": "4YMY",
+        "authority": "normal"
     },
     {
-        "secret_id": "gXXXlMxtjPb-NBcMjzYiahmbS0ItuhKO",
-        "public_id": "3DAA",
-        "authority": ""
+        "secret_id": "TFdC-Ckz30CmhRS8PozhwgT5qM6t1q3I",
+        "public_id": "7XHT",
+        "authority": "normal"
     },
     {
-        "secret_id": "LOX7qT8k5kmhWHza52edt_4O_YKjsflf",
-        "public_id": "6LFE",
-        "authority": ""
+        "secret_id": "RPb2_WV96OfmibLyE-5GXVLz7b71YORY",
+        "public_id": "4FEJ",
+        "authority": "normal"
     },
     {
-        "secret_id": "vreNwDa-Wo5dR0EuXJZYkzXWYDWnx5zq",
-        "public_id": "6JHF",
-        "authority": ""
+        "secret_id": "lr73g9neHNfaI215I6b4Av8Z-jFtWHK6",
+        "public_id": "9FXK",
+        "authority": "normal"
     },
     {
-        "secret_id": "V-b9Hb2M6ElF5lWDi0ZF_V6bud70NoOA",
-        "public_id": "3JRA",
-        "authority": ""
+        "secret_id": "3l7KWak-CfGI5pQtyT-tMkphJQhftDoe",
+        "public_id": "5EJK",
+        "authority": "normal"
     },
     {
-        "secret_id": "kogyVrCQTwUtaswztgQn4QtE5ZTvxx8m",
-        "public_id": "4NHF",
-        "authority": ""
+        "secret_id": "6ys5vXbm_J4WKXlvdVEFhLIM_b9XMtca",
+        "public_id": "3EPE",
+        "authority": "normal"
     },
     {
-        "secret_id": "FifMcSbdY2ZLzaUkVJfiOLmzdWrSTWUn",
-        "public_id": "6CAK",
-        "authority": ""
+        "secret_id": "c148WsrQP5xFKUNNvUWCL1gxAVDRJ_KZ",
+        "public_id": "6FEH",
+        "authority": "normal"
     },
     {
-        "secret_id": "RCco8aU0a_RRcPVmkzDGa3YOWFGovPLf",
-        "public_id": "5FXG",
-        "authority": ""
+        "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",
+        "public_id": "6JGL",
+        "authority": "normal"
     },
     {
-        "secret_id": "VPIokSPCWmHiSZlT99eYiEpIGrETjSJy",
-        "public_id": "9WXJ",
+        "secret_id": "GfVf96Ns9-NW9WI_Kc5KE8D4J4-ega9w",
+        "public_id": "7TCY",
         "authority": "admin"
     }
 ]


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
  
Step 2: 変更内容
----------------
#102 

Step 2: 検証手順
================

修正前の挙動:
-------------

  * `cards/id.py`でIDのJSONファイルを新規作成したときの
デフォルトの`authority`は空文字列
  
修正後の挙動:
-------------

  * デフォルトの`authority`が`normal`になる
  * `cards/test_users.json`が`admin`以外`normal`になっている

Step 3: 影響範囲
================

  * `login_required(*required_authority)`に渡す引数は`normal`を利用してください
この引数について一応補足すると、特に指定しなかった場合はすべての権限を制限せず、
何か指定すると（複数可）、その権限によるアクセスのみ許可します
  * `test_users.json`が変更されました
大丈夫だとは思いますが、IDが変更されると困るという場合は（まだないと思いますが）ご注意を
