### PR TITLE
`/lotteries/{id} [POST]`に、二度目以降のリクエストに対するエラーを追加する

### DIFF
--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -114,6 +114,11 @@ def apply_lottery(idx):
             for app in previous.all()):
         msg = "You're already applying to a lottery in this period"
         return jsonify({"message": msg}), 400
+    if any(app.lottery.index == lottery.index and
+            app.lottery.id == lottery.id
+            for app in previous.all()):
+        msg = "Your application is already accepted"
+        return jsonify({"message": msg}), 400
     application = previous.filter_by(lottery_id=lottery.id).first()
     # access DB
     if not application:

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -18,6 +18,7 @@ responses:
     description: >-
       Malformed Authenication Header has detected / Lottery has already
       done / You’re already applying to a lottery in this period
+      / Your application is already accepted
       / We're not accepting any application in this hours.
       / this lottery is not acceptable now.
     headers:

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -708,4 +708,4 @@ def test_draw_all_invalid(client):
     for i, (_, en) in enumerate(timepoints):
         res = datetime.timedelta.resolution
         try_with_datetime(mod_time(en, -res))
-        t
+        try_with_datetime(mod_time(en, +ext+res))

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -210,15 +210,16 @@ def test_apply_same_period(client):
 
     with client.application.app_context():
         target_lottery = Lottery.query.filter_by(id=idx).first()
+        index = target_lottery.index
         booking_lottery = Lottery.query.filter_by(
-            index=target_lottery.index).filter(Lottery.id != idx).first()
+            index=index).filter(Lottery.id != idx).first()
         user = User.query.filter_by(secret_id=test_user['secret_id']).first()
         application = Application(lottery=booking_lottery, user_id=user.id)
         db.session.add(application)
         db.session.commit()
 
     with mock.patch('api.routes.api.get_time_index',
-                    return_value=0):
+                    return_value=index):
         resp = client.post(f'/lotteries/{idx}',
                            headers={'Authorization': f'Bearer {token}'})
 
@@ -239,13 +240,14 @@ def test_apply_same_period_same_lottery(client):
 
     with client.application.app_context():
         target_lottery = Lottery.query.filter_by(id=idx).first()
+        index = target_lottery.index
         user = User.query.filter_by(secret_id=test_user['secret_id']).first()
         application = Application(lottery=target_lottery, user_id=user.id)
         db.session.add(application)
         db.session.commit()
 
     with mock.patch('api.routes.api.get_time_index',
-                    return_value=0):
+                    return_value=index):
         resp = client.post(f'/lotteries/{idx}',
                            headers={'Authorization': f'Bearer {token}'})
 
@@ -460,7 +462,7 @@ def test_draw(client):
         2. draws the lottery
         3. test: status code
         4. test: DB is changed
-        target_url: /lotteries/<id>/apply [PUT]
+        target_url: /lotteries/<id>/draw [PUT]
     """
     idx = 1
 
@@ -706,4 +708,4 @@ def test_draw_all_invalid(client):
     for i, (_, en) in enumerate(timepoints):
         res = datetime.timedelta.resolution
         try_with_datetime(mod_time(en, -res))
-        try_with_datetime(mod_time(en, +ext+res))
+        t


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

Step 1: 再現済み環境
====================

 * OS: Linux masato-laptop 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * devenv: 430fe0b0414b51beff2e40176899c2a5d494dc3c
 * frontend: ada3edcf5dde75e1c4843140165d7dbe9efd6db3
 * backend: 52770094694d9f549698bc7e8810c6ae431febd0
  
Step 2: 変更内容
----------------

#93 

Step 2: 検証手順
================

再現のための手順:
-----------------

`lotteries/{id}`で、同じところに、同じ抽選時間内に
複数回応募する
  
修正前の挙動:
-------------

普通に応募を処理
エラーなし
  
修正後の挙動:
-------------

`400 Your application is already accepted`
（エラーメッセージこれでいいですか）

Step 3: 影響範囲
================

なし

Unit test通過済み
