### PR TITLE
応募期間に一分間の猶予を追加-#95

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -19,6 +19,7 @@ class BaseConfig(object):
     START_DATETIME = datetime(2018, 9, 16, 8,  40, 0, tzinfo=TIMEZONE)
     END_DATETIME = datetime(2018, 9, 17, 16, 00, 0, tzinfo=TIMEZONE)
     DRAWING_TIME_EXTENSION = timedelta(minutes=10)
+    TIMEPOINT_END_MARGIN = timedelta(minutes=1)
     TIMEPOINTS = [
         (time(9,  20), time(9,  50)),
         (time(10, 45), time(11, 15)),

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -198,7 +198,7 @@ def draw_lottery(idx):
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return not_acceptable_resp, 400
 
-    if index != idx:
+    if index != lottery.index:
         return not_acceptable_resp, 400
 
     try:

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -89,9 +89,10 @@ def get_time_index(time=None):
           OutOfHoursError, OutOfAcceptingHoursError
     """
     time = _validate_and_get_time(time)
+    en_margin = current_app.config['TIMEPOINT_END_MARGIN']
 
     for i, (st, en) in enumerate(current_app.config['TIMEPOINTS']):
-        if st <= time <= en:
+        if st <= time <= mod_time(en, en_margin):
             return i
 
     raise OutOfAcceptingHoursError()

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -68,10 +68,11 @@ def get_draw_time_index(time=None):
           OutOfHoursError, OutOfAcceptingHoursError
     """
     time = _validate_and_get_time(time)
+    ext = current_app.config['DRAWING_TIME_EXTENSION']
+    en_margin = current_app.config['TIMEPOINT_END_MARGIN']
 
     for i, (_, en) in enumerate(current_app.config['TIMEPOINTS']):
-        ext = current_app.config['DRAWING_TIME_EXTENSION']
-        if en <= time <= mod_time(en, ext):
+        if mod_time(en, en_margin) <= time <= mod_time(en, ext):
             return i
 
     raise OutOfAcceptingHoursError()

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -535,9 +535,8 @@ def test_draw_group(client):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][index]
-        with mock.patch('api.time_management.get_current_datetime',
-                        return_value=end):
+        with mock.patch('api.routes.api.get_draw_time_index',
+                        return_value=index):
             resp = client.post(f'/lotteries/{idx}/draw',
                                headers={'Authorization': f'Bearer {token}'})
 
@@ -590,9 +589,8 @@ def test_draw_lots_of_groups(client, cnt):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][index]
-        with mock.patch('api.time_management.get_current_datetime',
-                        return_value=end):
+        with mock.patch('api.routes.api.get_draw_time_index',
+                        return_value=index):
             resp = client.post(f'/lotteries/{idx}/draw',
                                headers={'Authorization': f'Bearer {token}'})
 
@@ -649,9 +647,8 @@ def test_draw_lots_of_groups_and_normal(client, cnt):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][index]
-        with mock.patch('api.time_management.get_current_datetime',
-                        return_value=end):
+        with mock.patch('api.routes.api.get_draw_time_index',
+                        return_value=index):
             resp = client.post(f'/lotteries/{idx}/draw',
                                headers={'Authorization': f'Bearer {token}'})
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -379,6 +379,7 @@ def test_draw(client):
 
     with client.application.app_context():
         target_lottery = Lottery.query.filter_by(id=idx).first()
+        index = target_lottery.index
         users = User.query.all()
         for user in users:
             application = Application(lottery=target_lottery, user_id=user.id)
@@ -389,7 +390,7 @@ def test_draw(client):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        _, end = client.application.config['TIMEPOINTS'][index]
         end_margin = client.application.config['TIMEPOINT_END_MARGIN']
         end_with_margin = mod_time(end, end_margin)
         with mock.patch('api.time_management.get_current_datetime',

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -488,11 +488,11 @@ def test_draw_already_done(client):
         db.session.add(target_lottery)
         db.session.commit()
 
-    _, end = client.application.config['TIMEPOINTS'][int(idx)]
-    with mock.patch('api.time_management.get_current_datetime',
-                    return_value=end):
-        resp = client.post('/lotteries/'+idx+'/draw',
-                           headers={'Authorization': 'Bearer ' + token})
+        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        with mock.patch('api.routes.api.get_draw_time_index',
+                        return_value=target_lottery.index):
+            resp = client.post('/lotteries/'+idx+'/draw',
+                               headers={'Authorization': 'Bearer ' + token})
 
     assert resp.status_code == 400
     assert 'already done' in resp.get_json()['message']

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -390,8 +390,10 @@ def test_draw(client):
                       admin['g-recaptcha-response'])['token']
 
         _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        end_margin = client.application.config['TIMEPOINT_END_MARGIN']
+        end_with_margin = mod_time(end, end_margin)
         with mock.patch('api.time_management.get_current_datetime',
-                        return_value=end):
+                        return_value=end_with_margin):
             resp = client.post('/lotteries/'+idx+'/draw',
                                headers={'Authorization': 'Bearer ' + token})
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -552,7 +552,9 @@ def test_draw_all(client):
     token = login(client,
                   admin['secret_id'],
                   admin['g-recaptcha-response'])['token']
-    draw_time = client.application.config['TIMEPOINTS'][time_index][1]
+    _, en = client.application.config['TIMEPOINTS'][time_index]
+    en_margin = client.application.config['TIMEPOINT_END_MARGIN']
+    draw_time = mod_time(en, en_margin)
     with mock.patch('api.time_management.get_current_datetime',
                     return_value=draw_time):
         resp = client.post('/draw_all',

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -749,8 +749,8 @@ def test_draw_already_done(client):
 
         with mock.patch('api.routes.api.get_draw_time_index',
                         return_value=target_lottery.index):
-        resp = client.post(f'/lotteries/{idx}/draw',
-                           headers={'Authorization': f'Bearer {token}'})
+            resp = client.post(f'/lotteries/{idx}/draw',
+                               headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 400
     assert 'already done' in resp.get_json()['message']

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -744,7 +744,6 @@ def test_draw_already_done(client):
         target_lottery.done = True
         db.session.add(target_lottery)
 
-        index = target_lottery.index
         db.session.commit()
 
         with mock.patch('api.routes.api.get_draw_time_index',

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -483,12 +483,11 @@ def test_draw_already_done(client):
                   admin['g-recaptcha-response'])['token']
 
     with client.application.app_context():
-        target_lottery = Lottery.query.filter_by(id=idx).first()
+        target_lottery = Lottery.query.get(idx)
         target_lottery.done = True
         db.session.add(target_lottery)
         db.session.commit()
 
-        _, end = client.application.config['TIMEPOINTS'][int(idx)]
         with mock.patch('api.routes.api.get_draw_time_index',
                         return_value=target_lottery.index):
             resp = client.post('/lotteries/'+idx+'/draw',

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -73,12 +73,13 @@ def test_time_index_ooh(client):
 def test_time_index_ooa(client):
     with client.application.app_context():
         timepoints = client.application.config['TIMEPOINTS']
+        res = datetime.timedelta.resolution
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
         for i, point in enumerate(timepoints):
-            res = datetime.timedelta.resolution
             with pytest.raises(OutOfAcceptingHoursError):
                 get_time_index(mod_time(point[0], -res))
             with pytest.raises(OutOfAcceptingHoursError):
-                get_time_index(mod_time(point[1], +res))
+                get_time_index(mod_time(point[1], +res+en_margin))
 
 
 def test_time_index_lim(client):

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -51,8 +51,9 @@ def test_draw_time_index_same(client):
     with client.application.app_context():
         timepoints = client.application.config['TIMEPOINTS']
         ext = client.application.config['DRAWING_TIME_EXTENSION']
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
         for i, (_, en) in enumerate(timepoints):
-            idx_l = get_draw_time_index(en)
+            idx_l = get_draw_time_index(mod_time(en, en_margin))
             assert i == idx_l
             idx_r = get_draw_time_index(mod_time(en, +ext))
             assert i == idx_r

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -37,9 +37,11 @@ def test_draw_time_index_lim(client):
     with client.application.app_context():
         timepoints = client.application.config['TIMEPOINTS']
         ext = client.application.config['DRAWING_TIME_EXTENSION']
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
         for i, (_, en) in enumerate(timepoints):
+            en_with_margin = mod_time(en, en_margin)
             res = datetime.timedelta.resolution
-            idx_l = get_draw_time_index(mod_time(en, +res))
+            idx_l = get_draw_time_index(mod_time(en_with_margin, +res))
             assert i == idx_l
             idx_r = get_draw_time_index(mod_time(en, +ext-res))
             assert i == idx_r


### PR DESCRIPTION
Step 2: 変更内容
----------------

  * 委員会からの要望により、応募可能期間よりも1分すぎた時点までは応募できるようにします。
  * これは、ギリギリに応募処理をしようとしていてギリギリ応募できなかった...という自体を防ぐためです。
  * 該当issue #95

修正前の挙動:
-------------

  * 応募可能期間ぴったりまでしか応募ができず、1秒でも過ぎると応募が不可能になる。

修正後の挙動:
-------------

  * 応募可能期間から1分間は応募が可能に
  * それに伴い、抽選実行期間は実質9分になります（猶予期間の1分間は抽選できないため）
  * 尚抽選期間の10分から1分が猶予期間として使われるようになるだけで、他の時間は変更されません。（委員会より）

Step 3: 影響範囲
================

  * 今回の変更部分**以外**に、この変更が影響を与えそうなところがあったら書いてください