### PR TITLE
`/status`エンドポイントから`applications_history`を削除-#94

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -21,11 +21,6 @@ class UserSchema(Schema):
     id = fields.Int(dump_only=True)
     secret_id = fields.Str()
     public_id = fields.Method("get_public_id_str", dump_only=True)
-    application_history = fields.Method("get_applications", dump_only=True)
-
-    def get_applications(self, user):
-        lotteries = Application.query.filter_by(user_id=user.id).all()
-        return applications_schema.dump(lotteries)[0]
 
     def get_public_id_str(self, user):
         return encode_public_id(user.public_id)


### PR DESCRIPTION
This aims to remove applications history from '/status' endpoint.
'/draw' endpoints will lose those contents, too. But not a problem.


Step 2: 変更内容
----------------

  * `/status`エンドポイントから`applications_history`を削除しました
  * `UserSchema`から`applications_history`を消すという方法を取ったため、`draw`系でも`applications_history`が消えています。
  * related: #94


修正前の挙動:
-------------

  * `/status`エンドポイントのレスポンスに`applications_history`が含まれていた

修正後の挙動:
-------------

  * `/status`エンドポイントのレスポンスに`applications_history`が含まれていない

Step 3: 影響範囲
================

  * `/lotteries/{id}/draw`、`/draw_all`にて同様に`applications_history`が返ってこなくなりました