### PR TITLE
Fixspell mistake - Authenticate-#101

### DIFF
--- a/api/spec/routes/api/draw_all.yml
+++ b/api/spec/routes/api/draw_all.yml
@@ -15,7 +15,7 @@ responses:
   '401':
     description: Authorization Failed
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -25,7 +25,7 @@ responses:
   '403':
     description: You have no permission to perform the action
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -21,7 +21,7 @@ responses:
       / We're not accepting any application in this hours.
       / this lottery is not acceptable now.
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -31,7 +31,7 @@ responses:
   '401':
     description: Authorization Failed
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -41,7 +41,7 @@ responses:
   '403':
     description: You have no permission to perform the action
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field

--- a/api/spec/routes/api/lotteries/cancel.yml
+++ b/api/spec/routes/api/lotteries/cancel.yml
@@ -23,7 +23,7 @@ responses:
       already applying to a lottery in this period / You're not applying
       for this lottery
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -37,7 +37,7 @@ responses:
   '401':
     description: Authorization Failed
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field

--- a/api/spec/routes/api/lotteries/draw.yml
+++ b/api/spec/routes/api/lotteries/draw.yml
@@ -21,7 +21,7 @@ responses:
   '401':
     description: Authorization Failed
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -31,7 +31,7 @@ responses:
   '403':
     description: You have no permission to perform the action
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field

--- a/api/spec/routes/api/status.yml
+++ b/api/spec/routes/api/status.yml
@@ -11,7 +11,7 @@ responses:
   '400':
     description: Malformed Authenication Header has detected
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field
@@ -21,7 +21,7 @@ responses:
   '401':
     description: Authorization Failed
     headers:
-      WWW-Authenicate:
+      WWW-Authenticate:
         description: >-
           Authenication Error Code. For details, please refer to RFC 6750
           3. The WWW-Authenticate Response Header Field

--- a/api/spec/routes/auth.yml
+++ b/api/spec/routes/auth.yml
@@ -1,4 +1,4 @@
-Authenicate
+Authenticate
 ---
   consumes:
     - application/json
@@ -29,5 +29,5 @@ Authenicate
   tags:
     - user
   description: ''
-  operationId: Authenicate
+  operationId: Authenticate
   summary: Authenication

--- a/api/spec/template.yml
+++ b/api/spec/template.yml
@@ -213,7 +213,7 @@ x-components:
     Forbidden:
       description: You have no permission to perform the action
       headers:
-        WWW-Authenicate:
+        WWW-Authenticate:
           description: >-
             Authenication Error Code. For details, please refer to RFC 6750 3.
             The WWW-Authenticate Response Header Field
@@ -223,7 +223,7 @@ x-components:
     InvalidRequest:
       description: Malformed Authenication Header has detected
       headers:
-        WWW-Authenicate:
+        WWW-Authenticate:
           description: >-
             Authenication Error Code. For details, please refer to RFC 6750 3.
             The WWW-Authenticate Response Header Field
@@ -253,7 +253,7 @@ x-components:
     Unauthorized:
       description: Authorization Failed
       headers:
-        WWW-Authenicate:
+        WWW-Authenticate:
           description: >-
             Authenication Error Code. For details, please refer to RFC 6750 3.
             The WWW-Authenticate Response Header Field


### PR DESCRIPTION
This was done by oneliner:
```
$ git grep Authenticate | xargs sed -i '' -e 's/Authenicate/Authenticate/g'
```

Step 2: 変更内容
----------------

  * spell mistake を直したのじゃ〜