### PR TITLE
複数人の *抽選*

### DIFF
--- a/api/draw.py
+++ b/api/draw.py
@@ -55,7 +55,10 @@ def draw_one_group_members(applications, winners_num):
         decide win or lose for each group
         add applications to the session
     """
-    winner_apps = loser_apps = winner_reps = loser_reps = []
+    winner_apps = []
+    loser_apps = []
+    winner_reps = []
+    loser_reps = []
 
     def set_group_result(rep, is_won):
         status = "won" if is_won else "lose"

--- a/api/draw.py
+++ b/api/draw.py
@@ -63,9 +63,14 @@ def draw_one_group_members(applications, winners_num):
     winner_reps = [rep for rep in reps if random.random() < probability]
 
     winner_apps = set()
+    is_full = False
 
     for rep in reps:
-        is_won = rep in winner_reps
+        # when accidentally too many reps 'won' the lottery
+        is_full = is_full or \
+            len(winner_apps) + len(rep.group_members) + 1 > winners_num
+
+        is_won = (not is_full) and rep in winner_reps
         status = "won" if is_won else "lose"
 
         rep.status = status

--- a/api/draw.py
+++ b/api/draw.py
@@ -1,6 +1,6 @@
 import random
 from flask import current_app
-from api.models import User, Lottery, Application, db
+from api.models import Lottery, Application, db
 from itertools import chain
 
 
@@ -40,9 +40,8 @@ def draw_one(lottery):
         won_normal_users = draw_one_normal_users(applications,
                                                  rest_winners_num)
 
-        winners = [User.query.get(winner_app.user_id)
-                   for winner_app in chain(won_group_members,
-                                           won_normal_users)]
+        winners = [winner_app.user for winner_app in chain(won_group_members,
+                                                           won_normal_users)]
 
     db.session.add(lottery)
     db.session.commit()
@@ -69,17 +68,15 @@ def draw_one_group_members(applications, winners_num):
         to_apps.append(rep)
         to_reps.append(rep)
 
-        for member_id in rep.group_members:
-            member = Application.query.filter_by(user_id=member_id).first()
-            member.status = status
-            to_apps.append(member)
+        for member in rep.group_members:
+            member.own_application.status = status
+            to_apps.append(member.own_application)
 
     def unset_group_result(rep, from_apps, from_reps):
         from_apps.remove(rep)
         from_reps.remove(rep)
-        for member_id in rep.group_members:
-            member = Application.query.filter_by(user_id=member_id).first()
-            from_apps.remove(member)
+        for member in rep.group_members:
+            from_apps.remove(member.own_application)
 
     reps = [app for app in applications if app.is_rep]
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -55,12 +55,12 @@ def draw_one_group_members(applications, winners_num):
         decide win or lose for each group
         add applications to the session
     """
-    reps = (app for app in applications if app.is_rep)
+    reps = [app for app in applications if app.is_rep]
 
     # How likely is a rep to win
     probability = min(winners_num / len(applications), 1)
 
-    winner_reps = (rep for rep in reps if random.random() < probability)
+    winner_reps = [rep for rep in reps if random.random() < probability]
 
     winner_apps = set()
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -55,10 +55,7 @@ def draw_one_group_members(applications, winners_num):
         decide win or lose for each group
         add applications to the session
     """
-    winner_apps = []
-    loser_apps = []
-    winner_reps = []
-    loser_reps = []
+    winner_apps = loser_apps = winner_reps = loser_reps = []
 
     def set_group_result(rep, is_won):
         status = "won" if is_won else "lose"

--- a/api/draw.py
+++ b/api/draw.py
@@ -61,9 +61,9 @@ def draw_one_group_members(applications, winners_num):
     loser_reps = []
 
     def set_group_result(rep, is_won):
-        status = "won" if is_won else "lose"
-        to_apps = winner_apps if is_won else loser_apps
-        to_reps = winner_reps if is_won else loser_reps
+        status, to_apps, to_reps = \
+            ("won", winner_apps, winner_reps) if is_won \
+            else ("lose", loser_apps, loser_reps)
 
         rep.status = status
         to_apps.append(rep)

--- a/api/draw.py
+++ b/api/draw.py
@@ -1,6 +1,7 @@
 import random
 from flask import current_app
 from api.models import User, Lottery, Application, db
+from itertools import chain
 
 
 class AlreadyDoneError(Exception):
@@ -27,24 +28,78 @@ def draw_one(lottery):
 
     idx = lottery.id
     applications = Application.query.filter_by(lottery_id=idx).all()
-    if len(applications) == 0:
-        return []
 
-    try:
-        winner_apps = random.sample(
-            applications, current_app.config['WINNERS_NUM'])
-    except ValueError:
-        # if applications are less than WINNER_NUM, all applications are chosen
-        winner_apps = applications
-    for application in applications:
-        application.status = "won" if application in winner_apps else "lose"
-        db.session.add(application)
+    if len(applications) == 0:
+        winners = []
+    else:
+        winners_num = current_app.config['WINNERS_NUM']
+
+        won_group_members = draw_one_group_members(applications, winners_num)
+
+        rest_winners_num = winners_num - len(won_group_members)
+        won_normal_users = draw_one_normal_users(applications,
+                                                 rest_winners_num)
+
+        winners = [User.query.get(winner_app.user_id)
+                   for winner_app in chain(won_group_members,
+                                           won_normal_users)]
 
     db.session.add(lottery)
     db.session.commit()
-    winners = [User.query.get(winner_app.user_id)
-               for winner_app in winner_apps]
+
     return winners
+
+
+def draw_one_group_members(applications, winners_num):
+    """internal function
+        decide win or lose for each group
+        add applications to the session
+    """
+    reps = (app for app in applications if app.is_rep)
+
+    # How likely is a rep to win
+    probability = min(winners_num / len(applications), 1)
+
+    winner_reps = (rep for rep in reps if random.random() < probability)
+
+    winner_apps = set()
+
+    for rep in reps:
+        is_won = rep in winner_reps
+        status = "won" if is_won else "lose"
+
+        rep.status = status
+        db.session.add(rep)
+        if is_won:
+            winner_apps.add(rep)
+
+        for member_id in rep.group_members:
+            member = Application.query.filter_by(user_id=member_id).first()
+            member.status = status
+            db.session.add(member)
+            if is_won:
+                winner_apps.add(member)
+
+    return winner_apps
+
+
+def draw_one_normal_users(applications, winners_num):
+    """internal function
+        decide win or lose for each user not belonging to a group
+        add applications to the session
+    """
+    normal_users = [app for app in applications if app.status == "pending"]
+    try:
+        winner_apps = random.sample(normal_users, winners_num)
+    except ValueError:
+        # if applications are less than winners_num, all applications win
+        winner_apps = normal_users
+
+    for application in normal_users:
+        application.status = "won" if application in winner_apps else "lose"
+        db.session.add(application)
+
+    return winner_apps
 
 
 def draw_all_at_index(index):

--- a/api/draw.py
+++ b/api/draw.py
@@ -62,8 +62,8 @@ def draw_one_group_members(applications, winners_num):
 
     def set_group_result(rep, is_won):
         status = "won" if is_won else "lose"
-        to_apps, to_reps = \
-            (winner_apps, winner_reps) if is_won else (loser_apps, loser_reps)
+        to_apps = winner_apps if is_won else loser_apps
+        to_reps = winner_reps if is_won else loser_reps
 
         rep.status = status
         to_apps.append(rep)

--- a/api/draw.py
+++ b/api/draw.py
@@ -92,19 +92,17 @@ def draw_one_group_members(applications, winners_num):
     n_group_members = sum(len(rep_app.group_members) + 1 for rep_app in reps)
     n_normal_users = len(applications) - n_group_members
 
-    if len(winner_apps) < winners_num - n_normal_users:
-        # when too few groups accidentally won
-        while loser_reps and len(winner_apps) < winners_num - n_normal_users:
-            new_winner = random.choice(loser_reps)
-            unset_group_result(new_winner, loser_apps, loser_reps)
-            set_group_result(new_winner, True)
+    # when too few groups accidentally won
+    while loser_reps and len(winner_apps) < winners_num - n_normal_users:
+        new_winner = random.choice(loser_reps)
+        unset_group_result(new_winner, loser_apps, loser_reps)
+        set_group_result(new_winner, True)
 
-    if len(winner_apps) > winners_num:
-        # when too many groups accidentally won
-        while len(winner_apps) > winners_num:
-            new_loser = random.choice(winner_reps)
-            unset_group_result(new_loser, winner_apps, winner_reps)
-            set_group_result(new_loser, False)
+    # when too many groups accidentally won
+    while len(winner_apps) > winners_num:
+        new_loser = random.choice(winner_reps)
+        unset_group_result(new_loser, winner_apps, winner_reps)
+        set_group_result(new_loser, False)
 
     for user in chain(winner_apps, loser_apps):
         db.session.add(user)

--- a/api/draw.py
+++ b/api/draw.py
@@ -63,27 +63,31 @@ def draw_one_group_members(applications, winners_num):
     winner_reps = [rep for rep in reps if random.random() < probability]
 
     winner_apps = set()
-    is_full = False
+    loser_apps = set()
 
     for rep in reps:
-        # when accidentally too many reps 'won' the lottery
-        is_full = is_full or \
-            len(winner_apps) + len(rep.group_members) + 1 > winners_num
 
-        is_won = (not is_full) and rep in winner_reps
+        is_won = rep in winner_reps
         status = "won" if is_won else "lose"
 
         rep.status = status
         db.session.add(rep)
-        if is_won:
-            winner_apps.add(rep)
+        (winner_apps if is_won else loser_apps).add(rep)
 
         for member_id in rep.group_members:
             member = Application.query.filter_by(user_id=member_id).first()
             member.status = status
-            db.session.add(member)
-            if is_won:
-                winner_apps.add(member)
+            (winner_apps if is_won else loser_apps).add(member)
+
+    # TODO: needed?
+    # n_group_members = [len(rep_app.group_members) + 1 for rep_app in reps]
+
+    if len(winner_apps) > winners_num:
+        # TODO: when too many groups accidentally 'won'
+        pass
+    elif len(winner_apps) < winners_num - sum(winner_reps):
+        # TODO: when too few groups accidentally 'won'
+        pass
 
     return winner_apps
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -36,9 +36,7 @@ def draw_one(lottery):
 
         won_group_members = draw_one_group_members(applications, winners_num)
 
-        # TODO: for unit test until TODO below is done
-        # rest_winners_num = winners_num - len(won_group_members)
-        rest_winners_num = max(winners_num - len(won_group_members), 0)
+        rest_winners_num = winners_num - len(won_group_members)
         won_normal_users = draw_one_normal_users(applications,
                                                  rest_winners_num)
 
@@ -77,8 +75,8 @@ def draw_one_group_members(applications, winners_num):
             to_apps.append(member)
 
     def unset_group_result(rep, from_apps, from_reps):
-        print(f"unset {rep} from {from_apps}")
         from_apps.remove(rep)
+        from_reps.remove(rep)
         for member_id in rep.group_members:
             member = Application.query.filter_by(user_id=member_id).first()
             from_apps.remove(member)

--- a/api/draw.py
+++ b/api/draw.py
@@ -36,7 +36,9 @@ def draw_one(lottery):
 
         won_group_members = draw_one_group_members(applications, winners_num)
 
-        rest_winners_num = winners_num - len(won_group_members)
+        # TODO: for unit test until TODO below is done
+        # rest_winners_num = winners_num - len(won_group_members)
+        rest_winners_num = max(winners_num - len(won_group_members), 0)
         won_normal_users = draw_one_normal_users(applications,
                                                  rest_winners_num)
 
@@ -55,39 +57,59 @@ def draw_one_group_members(applications, winners_num):
         decide win or lose for each group
         add applications to the session
     """
+    winner_apps = []
+    loser_apps = []
+    winner_reps = []
+    loser_reps = []
+
+    def set_group_result(rep, is_won):
+        status = "won" if is_won else "lose"
+        to_apps, to_reps = \
+            (winner_apps, winner_reps) if is_won else (loser_apps, loser_reps)
+
+        rep.status = status
+        to_apps.append(rep)
+        to_reps.append(rep)
+
+        for member_id in rep.group_members:
+            member = Application.query.filter_by(user_id=member_id).first()
+            member.status = status
+            to_apps.append(member)
+
+    def unset_group_result(rep, from_apps, from_reps):
+        print(f"unset {rep} from {from_apps}")
+        from_apps.remove(rep)
+        for member_id in rep.group_members:
+            member = Application.query.filter_by(user_id=member_id).first()
+            from_apps.remove(member)
+
     reps = [app for app in applications if app.is_rep]
 
     # How likely is a rep to win
     probability = min(winners_num / len(applications), 1)
 
-    winner_reps = [rep for rep in reps if random.random() < probability]
-
-    winner_apps = set()
-    loser_apps = set()
-
     for rep in reps:
+        set_group_result(rep, random.random() < probability)
 
-        is_won = rep in winner_reps
-        status = "won" if is_won else "lose"
+    n_group_members = sum(len(rep_app.group_members) + 1 for rep_app in reps)
+    n_normal_users = len(applications) - n_group_members
 
-        rep.status = status
-        db.session.add(rep)
-        (winner_apps if is_won else loser_apps).add(rep)
-
-        for member_id in rep.group_members:
-            member = Application.query.filter_by(user_id=member_id).first()
-            member.status = status
-            (winner_apps if is_won else loser_apps).add(member)
-
-    # TODO: needed?
-    # n_group_members = [len(rep_app.group_members) + 1 for rep_app in reps]
+    if len(winner_apps) < winners_num - n_normal_users:
+        # when too few groups accidentally won
+        while loser_reps and len(winner_apps) < winners_num - n_normal_users:
+            new_winner = random.choice(loser_reps)
+            unset_group_result(new_winner, loser_apps, loser_reps)
+            set_group_result(new_winner, True)
 
     if len(winner_apps) > winners_num:
-        # TODO: when too many groups accidentally 'won'
-        pass
-    elif len(winner_apps) < winners_num - sum(winner_reps):
-        # TODO: when too few groups accidentally 'won'
-        pass
+        # when too many groups accidentally won
+        while len(winner_apps) > winners_num:
+            new_loser = random.choice(winner_reps)
+            unset_group_result(new_loser, winner_apps, winner_reps)
+            set_group_result(new_loser, False)
+
+    for user in chain(winner_apps, loser_apps):
+        db.session.add(user)
 
     return winner_apps
 

--- a/api/models.py
+++ b/api/models.py
@@ -103,10 +103,38 @@ class Application(db.Model):
                        default="pending",
                        nullable=False)
     is_rep = db.Column(db.Boolean, default=False)
-    group_members = db.Column(db.PickleType, default=[])
 
     def __repr__(self):
         return "<Application {}{}{} {}>".format(
                                             self.lottery, self.user,
                                             " (rep)" if self.is_rep else "",
                                             self.status)
+
+
+class GroupMember(db.Model):
+    """group-member model for DB
+        DB contents:
+            id (int): group member unique id
+            user_id (int): user id of this member
+            rep_application_id (int): rep application id
+    """
+    __tablename__ = 'group_members'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+            db.Integer,
+            db.ForeignKey('user.id', ondelete='CASCADE'),
+            db.ForeignKey('application.user_id', ondelete='CASCADE'))
+    user = db.relationship('User')
+    own_application = db.relationship('Application',
+                                      foreign_keys=[user_id],
+                                      viewonly=True)
+
+    rep_application_id = db.Column(db.Integer, db.ForeignKey(
+        'application.id', ondelete='CASCADE'))
+    rep_application = db.relationship('Application',
+                                      foreign_keys=[rep_application_id],
+                                      backref='group_members')
+
+    def __repr__(self):
+        return f"<GroupMemver {self.user}>"

--- a/api/models.py
+++ b/api/models.py
@@ -106,5 +106,7 @@ class Application(db.Model):
     group_members = db.Column(db.PickleType, default=[])
 
     def __repr__(self):
-        return "<Application {}{}{}>".format(self.lottery, self.user,
-                                             " (rep)" if self.is_rep else "")
+        return "<Application {}{}{} {}>".format(
+                                            self.lottery, self.user,
+                                            " (rep)" if self.is_rep else "",
+                                            self.status)

--- a/api/models.py
+++ b/api/models.py
@@ -84,6 +84,9 @@ class Application(db.Model):
             lottery_id (int): lottery id this application linked to
             user_id (int): user id of this application
             status (Boolen): whether chosen or not. initalized with None
+            is_rep (bool): whether rep of a group or not
+            group_members (pickled list): ids of other group members
+                                          (if is_rep is True)
     """
     __table_args__ = (UniqueConstraint(
         "lottery_id", "user_id", name="unique_idx_lottery_user"),)
@@ -99,6 +102,9 @@ class Application(db.Model):
     status = db.Column(db.String,
                        default="pending",
                        nullable=False)
+    is_rep = db.Column(db.Boolean, default=False)
+    group_members = db.Column(db.PickleType, default=[])
 
     def __repr__(self):
-        return "<Application {}{}>".format(self.lottery, self.user)
+        return "<Application {}{}{}>".format(self.lottery, self.user,
+                                             " (rep)" if self.is_rep else "")

--- a/api/models.py
+++ b/api/models.py
@@ -85,8 +85,6 @@ class Application(db.Model):
             user_id (int): user id of this application
             status (Boolen): whether chosen or not. initalized with None
             is_rep (bool): whether rep of a group or not
-            group_members (pickled list): ids of other group members
-                                          (if is_rep is True)
     """
     __table_args__ = (UniqueConstraint(
         "lottery_id", "user_id", name="unique_idx_lottery_user"),)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -7,6 +7,8 @@ class ApplicationSchema(Schema):
     id = fields.Int(dump_only=True)
     status = fields.Str()
     lottery = fields.Method("get_lottery", dump_only=True)
+    is_rep = fields.Boolean()
+    group_members = fields.List(fields.Int)
 
     def get_lottery(self, application):
         lottery = Lottery.query.get(application.lottery_id)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -18,7 +18,10 @@ users_schema = UserSchema(many=True)
 
 class GroupMemberSchema(Schema):
     id = fields.Int(dump_only=True)
-    user = fields.Nested(UserSchema)
+    public_id = fields.Method("get_public_id_str", dump_only=True)
+
+    def get_public_id_str(self, group_member):
+        return encode_public_id(group_member.user.public_id)
 
 
 group_member_schema = GroupMemberSchema()

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -3,22 +3,6 @@ from api.models import Application, Lottery
 from cards.id import encode_public_id
 
 
-class ApplicationSchema(Schema):
-    id = fields.Int(dump_only=True)
-    status = fields.Str()
-    lottery = fields.Method("get_lottery", dump_only=True)
-    is_rep = fields.Boolean()
-    group_members = fields.List(fields.Int)
-
-    def get_lottery(self, application):
-        lottery = Lottery.query.get(application.lottery_id)
-        return lottery_schema.dump(lottery)[0]
-
-
-application_schema = ApplicationSchema()
-applications_schema = ApplicationSchema(many=True)
-
-
 class UserSchema(Schema):
     id = fields.Int(dump_only=True)
     secret_id = fields.Str()
@@ -30,6 +14,31 @@ class UserSchema(Schema):
 
 user_schema = UserSchema()
 users_schema = UserSchema(many=True)
+
+
+class GroupMemberSchema(Schema):
+    id = fields.Int(dump_only=True)
+    user = fields.Nested(UserSchema)
+
+
+group_member_schema = GroupMemberSchema()
+group_members_schema = GroupMemberSchema(many=True)
+
+
+class ApplicationSchema(Schema):
+    id = fields.Int(dump_only=True)
+    status = fields.Str()
+    lottery = fields.Method("get_lottery", dump_only=True)
+    is_rep = fields.Boolean()
+    group_members = fields.Nested(GroupMemberSchema, many=True)
+
+    def get_lottery(self, application):
+        lottery = Lottery.query.get(application.lottery_id)
+        return lottery_schema.dump(lottery)[0]
+
+
+application_schema = ApplicationSchema()
+applications_schema = ApplicationSchema(many=True)
 
 
 class ClassroomSchema(Schema):

--- a/api/spec/template.yml
+++ b/api/spec/template.yml
@@ -33,7 +33,7 @@ definitions:
       is_rep:
         $ref: '#/definitions/RepresentativeMarker'
       group_members:
-        $ref: '#/definitions/GroupMembers'
+        $ref: '#/definitions/GroupMember'
     type: object
   ApplicationID:
     description: Application Identifier
@@ -49,9 +49,6 @@ definitions:
   RepresentativeMarker:
     description: Marker of the reps of applying groups
     type: boolean
-  GroupMembers:
-    description: List of group members' IDs (User#id) the rep alone has
-    type: list
   Certificate:
     properties:
       g-recaptcha-response:
@@ -164,6 +161,25 @@ definitions:
         $ref: '#/definitions/SecretID'
       public_id:
         $ref: '#/definitions/PublicID'
+    type: object
+  GroupMember:
+    properties:
+      id:
+        $ref: '#/definitions/GroupMemberID'
+      own_application:
+        $ref: '#/definitions/OwnApplication'
+      rep_application:
+        $ref: '#/definitions/RepApplication'
+    type: object
+  GroupMemberID:
+    description: Group Member ID
+    example: 0
+    type: integer
+  OwnApplication:
+    description: a group member's personal application
+    type: object
+  RepApplication:
+    description: application of the rep of the group
     type: object
 securityDefinitions:
   admin_auth:

--- a/api/spec/template.yml
+++ b/api/spec/template.yml
@@ -30,6 +30,10 @@ definitions:
         $ref: '#/definitions/Lottery'
       status:
         $ref: '#/definitions/ApplicationStatus'
+      is_rep:
+        $ref: '#/definitions/RepresentativeMarker'
+      group_members:
+        $ref: '#/definitions/GroupMembers'
     type: object
   ApplicationID:
     description: Application Identifier
@@ -42,6 +46,12 @@ definitions:
       - won
       - lose
     type: string
+  RepresentativeMarker:
+    description: Marker of the reps of applying groups
+    type: boolean
+  GroupMembers:
+    description: List of group members' IDs (User#id) the rep alone has
+    type: list
   Certificate:
     properties:
       g-recaptcha-response:

--- a/docs/uml/api-models_class.uml
+++ b/docs/uml/api-models_class.uml
@@ -34,6 +34,8 @@ class Application {
   + user_id
   + user
   + status
+  + is_rep
+  + group_members
   + __repr__()
 }
 

--- a/docs/uml/api-models_class.uml
+++ b/docs/uml/api-models_class.uml
@@ -39,4 +39,15 @@ class Application {
   + __repr__()
 }
 
+class GroupMember {
+  + __tablename__
+  + id
+  + user_id
+  + user
+  + own_application
+  + rep_application_id
+  + rep_application
+  + __repr__()
+}
+
 @enduml

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -22,6 +22,7 @@ from api.schemas import (
     lottery_schema
 )
 from api.time_management import mod_time
+from itertools import chain
 
 
 # ---------- Lottery API
@@ -518,9 +519,9 @@ def test_draw_group(client):
                                       user_id=user.id)
             db.session.add(application)
         rep_application = Application(
-                lottery=target_lottery,
-                user_id=users[0].id, is_rep=True,
-                group_members=[user.id for user in users[1:group_size]])
+            lottery=target_lottery,
+            user_id=users[0].id, is_rep=True,
+            group_members=[user.id for user in users[1:group_size]])
         db.session.add(rep_application)
         db.session.commit()
 
@@ -540,11 +541,67 @@ def test_draw_group(client):
         target_lottery = Lottery.query.filter_by(id=idx).first()
         assert target_lottery.done
         rep_status = Application.query.filter_by(
-                lottery=target_lottery, user_id=users[0].id).first().status
+            lottery=target_lottery, user_id=users[0].id).first().status
         for user in users[1:group_size]:
             application = Application.query.filter_by(
                 lottery=target_lottery, user_id=user.id).first()
             assert application.status == rep_status
+
+
+def test_draw_lots_of_groups(client):
+    """attempt to draw a lottery as 2 groups of 2 members
+            while WINNERS_NUM is 3
+        1. make some applications to one lottery as groups
+        2. draws the lottery
+        3. test: status code
+        4. test: DB is changed
+        5. test: result of each member
+        6. test: number of winners
+        target_url: /lotteries/<id>/draw [POST]
+    """
+    idx = 1
+    members = (0, 1)
+    reps = (2, 3)
+
+    with client.application.app_context():
+        target_lottery = Lottery.query.filter_by(id=idx).first()
+        users = User.query.all()
+        members_app = [Application(lottery=target_lottery, user_id=users[i].id)
+                       for i in members]
+        reps_app = [Application(
+                    lottery=target_lottery,
+                    user_id=users[i].id, is_rep=True,
+                    group_members=[users[j].id])
+                    for i, j in zip(reps, members)]
+
+        for application in chain(members_app, reps_app):
+            db.session.add(application)
+        db.session.commit()
+
+        token = login(client,
+                      admin['secret_id'],
+                      admin['g-recaptcha-response'])['token']
+
+        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        with mock.patch('api.time_management.get_current_datetime',
+                        return_value=end):
+            resp = client.post(f'/lotteries/{idx}/draw',
+                               headers={'Authorization': f'Bearer {token}'})
+
+        assert resp.status_code == 200
+
+        winners = resp.get_json()
+        assert len(winners) <= client.application.config['WINNERS_NUM']
+
+        users = User.query.all()
+        target_lottery = Lottery.query.filter_by(id=idx).first()
+        assert target_lottery.done
+        for i, j in zip(reps, members):
+            rep_status = Application.query.filter_by(
+                lottery=target_lottery, user_id=users[i].id).first().status
+            member_status = Application.query.filter_by(
+                    lottery=target_lottery, user_id=users[j].id).first().status
+            assert rep_status == member_status
 
 
 def test_draw_noperm(client):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -548,7 +548,8 @@ def test_draw_group(client):
             assert application.status == rep_status
 
 
-def test_draw_lots_of_groups(client):
+@pytest.mark.parametrize("cnt", range(20))
+def test_draw_lots_of_groups(client, cnt):
     """attempt to draw a lottery as 2 groups of 2 members
             while WINNERS_NUM is 3
         1. make some applications to one lottery as groups

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -12,7 +12,7 @@ from utils import (
     make_application
 )
 
-from api.models import Lottery, Classroom, User, Application, db
+from api.models import Lottery, Classroom, User, Application, GroupMember, db
 from api.schemas import (
     classrooms_schema,
     classroom_schema,
@@ -523,7 +523,9 @@ def test_draw_group(client):
         rep_application = Application(
             lottery=target_lottery,
             user_id=users[0].id, is_rep=True,
-            group_members=[user.id for user in users[1:group_size]])
+            group_members=[GroupMember(user_id=user.id)
+                           for user in users[1:group_size]])
+
         db.session.add(rep_application)
         db.session.commit()
 
@@ -575,7 +577,7 @@ def test_draw_lots_of_groups(client, cnt):
         reps_app = [Application(
                     lottery=target_lottery,
                     user_id=users[i].id, is_rep=True,
-                    group_members=[users[j].id])
+                    group_members=[GroupMember(user_id=users[j].id)])
                     for i, j in zip(reps, members)]
 
         for application in chain(members_app, reps_app):
@@ -634,7 +636,7 @@ def test_draw_lots_of_groups_and_normal(client, cnt):
         reps_app = [Application(
                     lottery=target_lottery,
                     user_id=users[i].id, is_rep=True,
-                    group_members=[users[j].id])
+                    group_members=[GroupMember(user_id=users[j].id)])
                     for i, j in zip(reps, members)]
 
         for application in chain(members_app, reps_app):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -166,7 +166,7 @@ def test_apply_noperm(client):
 
 def test_apply_invalid(client):
     """attempt to apply to non-exsit lottery
-        target_url: /lotteries/<id> [PUT]
+        target_url: /lotteries/<id> [POST]
     """
     idx = invalid_lottery_id
     token = login(client, test_user['secret_id'],

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -513,7 +513,8 @@ def test_draw_group(client):
     group_size = 3
 
     with client.application.app_context():
-        target_lottery = Lottery.query.filter_by(id=idx).first()
+        target_lottery = Lottery.query.get(idx)
+        index = target_lottery.index
         users = User.query.all()
         for user in users[1:]:
             application = Application(lottery=target_lottery,
@@ -530,7 +531,7 @@ def test_draw_group(client):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        _, end = client.application.config['TIMEPOINTS'][index]
         with mock.patch('api.time_management.get_current_datetime',
                         return_value=end):
             resp = client.post(f'/lotteries/{idx}/draw',
@@ -567,6 +568,7 @@ def test_draw_lots_of_groups(client, cnt):
 
     with client.application.app_context():
         target_lottery = Lottery.query.filter_by(id=idx).first()
+        index = target_lottery.index
         users = User.query.all()
         members_app = [Application(lottery=target_lottery, user_id=users[i].id)
                        for i in members]
@@ -584,7 +586,7 @@ def test_draw_lots_of_groups(client, cnt):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        _, end = client.application.config['TIMEPOINTS'][index]
         with mock.patch('api.time_management.get_current_datetime',
                         return_value=end):
             resp = client.post(f'/lotteries/{idx}/draw',
@@ -625,6 +627,7 @@ def test_draw_lots_of_groups_and_normal(client, cnt):
 
     with client.application.app_context():
         target_lottery = Lottery.query.filter_by(id=idx).first()
+        index = target_lottery.index
         users = User.query.all()
         members_app = [Application(lottery=target_lottery, user_id=users[i].id)
                        for i in chain(members, normal)]
@@ -642,7 +645,7 @@ def test_draw_lots_of_groups_and_normal(client, cnt):
                       admin['secret_id'],
                       admin['g-recaptcha-response'])['token']
 
-        _, end = client.application.config['TIMEPOINTS'][int(idx)]
+        _, end = client.application.config['TIMEPOINTS'][index]
         with mock.patch('api.time_management.get_current_datetime',
                         return_value=end):
             resp = client.post(f'/lotteries/{idx}/draw',


### PR DESCRIPTION
Step 1: 再現済み環境
====================

 * OS: Linux masato-laptop 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * devenv: 3a52ddee4795e0c9327ff93dfb1fd99d0054cf6e
 * frontend: d142c3dbac1628263de32c64960b47c4491dc658
 * backend: 2ada7d57d4c9f64f99cc7b66a8151a2343c69a18

  
Step 2: 変更内容
----------------

  * #115 
現抽選プロトコル：https://github.com/Sakuten/backend/issues/115#issuecomment-410704865
  * Applicationモデルの変更（is_rep、group_membersの追加）　以下 #37 の引用
```yaml
is_rep (bool): 代表者の確率で抽選するときに必要
               これを複数人応募のグループを見分けるグループID代わりに利用する
group_members (list): 他のメンバーのID
                      代表者だけ保持していれば十分
```
  * ↑に伴うスキーマ、Swaggerのテンプレート、UMLの更新
  * ユニットテストの追加
  * ユニットテスト内docstringのtypoを修正

Step 2: 検証手順
================

1. `is_rep=True`、`group_members=[user_id, user_id, ...]`のパラメータを渡して作成した`Application`を作成する
2. 各`user_id`の`Application`を作成する
3. 各`Application`をデータベースに保存し、`api/draw.py`の`draw_one`関数、`draw_all_at_index`関数を呼び出す
（`(admin) /lotteries/{id}/draw [POST]`または`(admin) /draw_all [POST]`）

#116 の応募プログラムが未完成であるため、直接`Application`を作成するユニットテスト以外の検証は不可

Step 3: 影響範囲
================
`Application#is_rep`はデフォルトで`False`であり、
`Application#group_members`もデフォルトで`[]`なので、
今回の`Application`モデルの変更による既存コードへの影響は全くありません。
個人応募の`Application`も全く同じ方法で作成できます。
