### PR TITLE
`/status`エンドポイントの仕様書を書き直した - #133

### DIFF
--- a/api/spec/template.yml
+++ b/api/spec/template.yml
@@ -153,10 +153,6 @@ definitions:
     type: string
   User:
     properties:
-      application_history:
-        items:
-          $ref: '#/definitions/Application'
-        type: array
       secret_id:
         $ref: '#/definitions/SecretID'
       public_id:


### PR DESCRIPTION
これは本来、#94にて修正されるべきだったが、自分がすっかり忘れていたために、
決まった仕様とは異なる形でドキュメントが残っていました。
そのため削除した次第です。