### PR TITLE
`apply`のエラーレスポンスから、`already done`を削除する

### DIFF
--- a/api/draw.py
+++ b/api/draw.py
@@ -4,13 +4,6 @@ from api.models import Lottery, Application, db
 from itertools import chain
 
 
-class AlreadyDoneError(Exception):
-    """
-        The Exception that indicates the lottery has already done
-    """
-    pass
-
-
 def draw_one(lottery):
     """
         Draw the specified lottery
@@ -21,9 +14,6 @@ def draw_one(lottery):
         Raises:
             AlreadyDoneError
     """
-    if lottery.done:
-        raise AlreadyDoneError()
-
     lottery.done = True
 
     idx = lottery.id
@@ -133,12 +123,8 @@ def draw_all_at_index(index):
           index(int): zero-based index that indicates the time of lottery
         Return:
           winners([[User]]): The list of list of users who won
-        Raises:
-            AlreadyDoneError
     """
     lotteries = Lottery.query.filter_by(index=index)
-    if any(lottery.done for lottery in lotteries):
-        raise AlreadyDoneError()
 
     winners = [draw_one(lottery)
                for lottery in lotteries]

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -139,7 +139,7 @@ def apply_lottery(idx):
                    app.lottery.id != lottery.id
                    for app in previous.all()):
                 msg = "someone in the group is already " \
-                    "applying to a lottery in this period"
+                      "applying to a lottery in this period"
                 return jsonify({"message": msg}), 400
             if any(app.lottery.index == lottery.index and
                    app.lottery.id == lottery.id
@@ -270,7 +270,6 @@ def draw_lottery(idx):
     winners = draw_one(lottery)
 
     result = users_schema.dump(winners)
-
     return jsonify(result[0])
 
 

--- a/api/spec/routes/api/draw_all.yml
+++ b/api/spec/routes/api/draw_all.yml
@@ -9,7 +9,7 @@ responses:
         $ref: '#/definitions/User'
       type: array
   '400':
-    description: Malformed Authenication Header has detected / Not acceptable time / This lottery has already done
+    description: Malformed Authenication Header has detected / Not acceptable time
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':

--- a/api/spec/routes/api/lotteries/apply.yml
+++ b/api/spec/routes/api/lotteries/apply.yml
@@ -27,8 +27,8 @@ responses:
       $ref: '#/definitions/Application'
   '400':
     description: >-
-      Malformed Authenication Header has detected / Lottery has already
-      done / You’re already applying to a lottery in this period
+      Malformed Authenication Header has detected
+      / You’re already applying to a lottery in this period
       / Your application is already accepted
       / We're not accepting any application in this hours.
       / this lottery is not acceptable now.

--- a/api/spec/routes/api/lotteries/cancel.yml
+++ b/api/spec/routes/api/lotteries/cancel.yml
@@ -19,9 +19,8 @@ responses:
       type: object
   '400':
     description: >-
-      Invalid Request / Lottery has already done / You're
-      already applying to a lottery in this period / You're not applying
-      for this lottery
+      Invalid Request / You're already applying to a lottery in this period
+      / You're not applying for this lottery
     headers:
       WWW-Authenticate:
         description: >-

--- a/api/spec/routes/api/lotteries/draw.yml
+++ b/api/spec/routes/api/lotteries/draw.yml
@@ -15,7 +15,7 @@ responses:
     schema:
       $ref: '#/definitions/User'
   '400':
-    description: Malformed Authenication Header has detected / Not acceptable time / This lottery has already done
+    description: Malformed Authenication Header has detected / Not acceptable time
     schema:
       $ref: '#/definitions/ErrorMessage'
   '401':

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -207,7 +207,7 @@ def test_apply_already_done(client):
                        json={'group_members': []})
 
     assert resp.status_code == 400
-    assert 'already done' in resp.get_json()['message']
+    assert "any application in this hours." in resp.get_json()['message']
 
 
 def test_apply_same_period(client):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -187,29 +187,6 @@ def test_apply_invalid(client):
     assert 'Lottery could not be found.' in resp.get_json()['message']
 
 
-def test_apply_already_done(client):
-    """attempt to apply previously drawn application.
-        1. test: error is returned
-        target_url: /lotteries/<id> [POST]
-    """
-    idx = 1
-    token = login(client, test_user['secret_id'],
-                  test_user['g-recaptcha-response'])['token']
-
-    with client.application.app_context():
-        target_lottery = Lottery.query.filter_by(id=idx).first()
-        target_lottery.done = True
-        db.session.add(target_lottery)
-        db.session.commit()
-
-    resp = client.post(f'/lotteries/{idx}',
-                       headers={'Authorization': f'Bearer {token}'},
-                       json={'group_members': []})
-
-    assert resp.status_code == 400
-    assert "any application in this hours." in resp.get_json()['message']
-
-
 def test_apply_same_period(client):
     """attempt to apply to the same period with the previous application
         1. test: error is returned

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -883,31 +883,6 @@ def test_draw_time_invalid(client):
     try_with_datetime(mod_time(en, +ext+res))
 
 
-def test_draw_already_done(client):
-    """attempt to draw previously drawn lottery.
-        1. test: error is returned
-        target_url: /lotteries/<id>/draw [POST]
-    """
-    idx = 1
-    token = login(client, admin['secret_id'],
-                  admin['g-recaptcha-response'])['token']
-
-    with client.application.app_context():
-        target_lottery = Lottery.query.get(idx)
-        target_lottery.done = True
-        db.session.add(target_lottery)
-
-        db.session.commit()
-
-        with mock.patch('api.routes.api.get_draw_time_index',
-                        return_value=target_lottery.index):
-            resp = client.post(f'/lotteries/{idx}/draw',
-                               headers={'Authorization': f'Bearer {token}'})
-
-    assert resp.status_code == 400
-    assert 'already done' in resp.get_json()['message']
-
-
 @pytest.mark.skip(reason='not implemented yet')
 def test_draw_nobody_apply(client):
     """attempt to draw a lottery that nobody applying


### PR DESCRIPTION
 * OS: Linux masato-laptop 4.15.0-33-generic #36-Ubuntu SMP Wed Aug 15 16:00:05 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * devenv: 3c7149cce36dbdaa611a642d4aedd97ea86028c1
 * frontend: d123b3b62451671818ca9dbbb3ef8ee77e1c8aea
 * backend: 369323c5661542439c027a6a8a18a9e74c70759d

変更内容
================
  * #117 
> * #96 のマージにより、応募可能な時間帯を制限することにより、既に終わったlotteryに応募することは不可能になりました。
> * これは、aleady doneのレスポンスが目的としていた行為を含んでおり、二重に同じ処理をかけるのはコード的にもよろしくないし、のちのリファクタリングにて混乱を招くだけだと思いました。

影響範囲
================
なし