### PR TITLE
translate_secret_to_publicでの単語ミスを直した

### DIFF
--- a/api/spec/routes/api/translate_secret_to_public.yml
+++ b/api/spec/routes/api/translate_secret_to_public.yml
@@ -14,8 +14,8 @@ responses:
     schema:
       type: "object"
       properties:
-        secret_id:
-          $ref: '#/definitions/SecretID'
+        public_id:
+          $ref: '#/definitions/PublicID'
   '404':
     description: no such user found
     schema:


### PR DESCRIPTION
変更内容
================

  * `translate_secret_to_public.xml`を作成する際、`public_id`とするべきところを間違えて`secret_id`としていたのでその修正
  * #137

修正前の挙動:
-------------

  * specにて、`/public_id`の記述がおかしかった
  * 具体的には、成功時の返り値が`public_id`であるはずなのに`secret_id`となっていた

修正後の挙動:
-------------

  * 仕様通りになった