### PR TITLE
1日目に使用されたuser idを2日目に無効化-#78

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -124,7 +124,8 @@ def generate():
     for ids in id_list:
         user = User(secret_id=ids['secret_id'],
                     public_id=decode_public_id(ids['public_id']),
-                    authority=ids['authority'])
+                    authority=ids['authority'],
+                    kind=ids['kind'])
         db.session.add(user)
 
     db.session.commit()

--- a/api/auth.py
+++ b/api/auth.py
@@ -83,7 +83,9 @@ def login_required(*required_authority):
             data = decrypt_token(token)
             if not data:
                 return auth_error(401, 'error="invalid_token"')
-            user = User.query.filter_by(id=data['data']['user_id']).first()
+            user = todays_user(data['data']['user_id'])
+            if user is None:
+                return auth_error(401, 'realm="id_disabled"')
             if required_authority and \
                     (user.authority not in required_authority):
                 return auth_error(403, 'error="insufficient_scope"')

--- a/api/auth.py
+++ b/api/auth.py
@@ -83,7 +83,7 @@ def login_required(*required_authority):
             data = decrypt_token(token)
             if not data:
                 return auth_error(401, 'error="invalid_token"')
-            user = todays_user(data['data']['user_id'])
+            user = todays_user(user_id=data['data']['user_id'])
             if user is None:
                 return auth_error(401, 'realm="id_disabled"')
             if required_authority and \

--- a/api/auth.py
+++ b/api/auth.py
@@ -96,7 +96,7 @@ def login_required(*required_authority):
     return login_required_impl
 
 
-def todays_user(secret_id):
+def todays_user(secret_id='', user_id=''):
     """confirm the user id isn't used in other day
         and return `User` object
         Args:
@@ -109,7 +109,10 @@ def todays_user(secret_id):
             https://github.com/Sakuten/backend/issues/78#issuecomment-416609508
     """
 
-    user = User.query.filter_by(secret_id=secret_id).first()
+    if secret_id:
+        user = User.query.filter_by(secret_id=secret_id).first()
+    elif user_id:
+        user = User.query.get(user_id)
 
     if not user:
         return None

--- a/api/auth.py
+++ b/api/auth.py
@@ -116,6 +116,8 @@ def todays_user(secret_id='', user_id=''):
 
     if not user:
         return None
+    if user.kind not in current_app.config['ONE_DAY_KIND']:
+        return user
 
     if user.first_access is None:
         user.first_access = date.today()

--- a/api/config.py
+++ b/api/config.py
@@ -26,6 +26,7 @@ class BaseConfig(object):
         (time(12, 25), time(12, 55)),
         (time(13, 50), time(14, 20)),
     ]
+    ONE_DAY_KIND = ['visitor']
 
 
 class DevelopmentConfig(BaseConfig):

--- a/api/models.py
+++ b/api/models.py
@@ -19,6 +19,7 @@ class User(db.Model):
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
+    first_access = db.Column(db.Date)
 
     def __repr__(self):
         authority_str = f'({self.authority})' if self.authority else ''

--- a/api/models.py
+++ b/api/models.py
@@ -19,7 +19,7 @@ class User(db.Model):
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
-    first_access = db.Column(db.Date)
+    first_access = db.Column(db.Date, default=None)
 
     def __repr__(self):
         authority_str = f'({self.authority})' if self.authority else ''

--- a/api/models.py
+++ b/api/models.py
@@ -19,6 +19,7 @@ class User(db.Model):
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
+    kind = db.Column(db.String(30))
     first_access = db.Column(db.Date, default=None)
 
     def __repr__(self):

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -1,15 +1,7 @@
 from itertools import chain
 
 from flask import Blueprint, jsonify, g, request
-from api.models import (
-    Lottery,
-    Classroom,
-    User,
-    Application,
-    db,
-    GroupMember,
-    todays_user
-)
+from api.models import Lottery, Classroom, User, Application, db, GroupMember
 from api.schemas import (
     user_schema,
     users_schema,
@@ -20,7 +12,7 @@ from api.schemas import (
     lotteries_schema,
     lottery_schema
 )
-from api.auth import login_required
+from api.auth import login_required, todays_user
 from api.swagger import spec
 from api.time_management import (
     get_draw_time_index,
@@ -137,7 +129,7 @@ def apply_lottery(idx):
     group_members = []
     if len(group_members_secret_id) != 0:
         for sec_id in group_members_secret_id:
-            user = todays_user(sec_id)
+            user = todays_user(secret_id=sec_id)
             if user is not None:
                 group_members.append(user)
             else:

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -1,7 +1,15 @@
 from itertools import chain
 
 from flask import Blueprint, jsonify, g, request
-from api.models import Lottery, Classroom, User, Application, db, GroupMember
+from api.models import (
+    Lottery,
+    Classroom,
+    User,
+    Application,
+    db,
+    GroupMember,
+    todays_user
+)
 from api.schemas import (
     user_schema,
     users_schema,
@@ -129,7 +137,7 @@ def apply_lottery(idx):
     group_members = []
     if len(group_members_secret_id) != 0:
         for sec_id in group_members_secret_id:
-            user = User.query.filter_by(secret_id=sec_id).first()
+            user = todays_user(sec_id)
             if user is not None:
                 group_members.append(user)
             else:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -2,8 +2,7 @@ from flask import Blueprint, jsonify, request, current_app
 from urllib.request import urlopen
 import json
 from ipaddress import ip_address
-from api.models import User
-from api.auth import generate_token
+from api.auth import generate_token, todays_user
 from api.swagger import spec
 
 bp = Blueprint(__name__, 'auth')
@@ -30,7 +29,7 @@ def home():
     # login flow
     secret_id = data.get('id')
     recaptcha_code = data.get('g-recaptcha-response')
-    user = User.query.filter_by(secret_id=secret_id).first()
+    user = todays_user(secret_id)
     if user:
         if not ip_address(request.remote_addr).is_private:
             secret_key = current_app.config['RECAPTCHA_SECRET_KEY']

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -29,7 +29,7 @@ def home():
     # login flow
     secret_id = data.get('id')
     recaptcha_code = data.get('g-recaptcha-response')
-    user = todays_user(secret_id)
+    user = todays_user(secret_id=secret_id)
     if user:
         if not ip_address(request.remote_addr).is_private:
             secret_key = current_app.config['RECAPTCHA_SECRET_KEY']

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -3,19 +3,19 @@
         "secret_id": "nCGX_hMrMZxRAak-W36kIzzxrup_SIKI",
         "public_id": "6YGW",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
         "public_id": "5RAX",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "zmPplhO29m7dMNDdLnt4MtO_aFONrViC",
         "public_id": "4YMY",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "TFdC-Ckz30CmhRS8PozhwgT5qM6t1q3I",
@@ -45,24 +45,24 @@
         "secret_id": "6ys5vXbm_J4WKXlvdVEFhLIM_b9XMtca",
         "public_id": "3EPE",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "checker"
     },
     {
         "secret_id": "c148WsrQP5xFKUNNvUWCL1gxAVDRJ_KZ",
         "public_id": "6FEH",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "checker"
     },
     {
         "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",
         "public_id": "6JGL",
         "authority": "normal",
-        "kind": "student"
+        "kind": "checker"
     },
     {
         "secret_id": "GfVf96Ns9-NW9WI_Kc5KE8D4J4-ega9w",
         "public_id": "7TCY",
         "authority": "admin",
-        "kind": "staff"
+        "kind": "admin"
     }
 ]

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -2,7 +2,8 @@
     {
         "secret_id": "nCGX_hMrMZxRAak-W36kIzzxrup_SIKI",
         "public_id": "6YGW",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
@@ -56,7 +57,7 @@
         "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",
         "public_id": "6JGL",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "GfVf96Ns9-NW9WI_Kc5KE8D4J4-ega9w",

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -7,51 +7,61 @@
     {
         "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
         "public_id": "5RAX",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "zmPplhO29m7dMNDdLnt4MtO_aFONrViC",
         "public_id": "4YMY",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "TFdC-Ckz30CmhRS8PozhwgT5qM6t1q3I",
         "public_id": "7XHT",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "RPb2_WV96OfmibLyE-5GXVLz7b71YORY",
         "public_id": "4FEJ",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "lr73g9neHNfaI215I6b4Av8Z-jFtWHK6",
         "public_id": "9FXK",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "3l7KWak-CfGI5pQtyT-tMkphJQhftDoe",
         "public_id": "5EJK",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "6ys5vXbm_J4WKXlvdVEFhLIM_b9XMtca",
         "public_id": "3EPE",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "c148WsrQP5xFKUNNvUWCL1gxAVDRJ_KZ",
         "public_id": "6FEH",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",
         "public_id": "6JGL",
-        "authority": "normal"
+        "authority": "normal",
+        "kind": "visitor"
     },
     {
         "secret_id": "GfVf96Ns9-NW9WI_Kc5KE8D4J4-ega9w",
         "public_id": "7TCY",
-        "authority": "admin"
+        "authority": "admin",
+        "kind": "staff"
     }
 ]

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -9,13 +9,13 @@
         "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
         "public_id": "5RAX",
         "authority": "normal",
-        "kind": "student"
+        "kind": "visitor"
     },
     {
         "secret_id": "zmPplhO29m7dMNDdLnt4MtO_aFONrViC",
         "public_id": "4YMY",
         "authority": "normal",
-        "kind": "student"
+        "kind": "visitor"
     },
     {
         "secret_id": "TFdC-Ckz30CmhRS8PozhwgT5qM6t1q3I",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,7 +34,7 @@ def client():
     admin['secret_id'] = admin_cred['secret_id']
     student_cred = next(i for i in id_list if i['kind'] == 'student')
     test_student['secret_id'] = student_cred['secret_id']
-    test_creds = (i for i in id_list if i['authority'] != 'admin')
+    test_creds = (i for i in id_list if i['kind'] == 'visitor')
     for user in [test_user, test_user1, test_user2, test_user3,
                  test_user4, test_user5]:
         test_cred = next(test_creds)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ from api import app
 from cards.id import load_id_json_file
 
 from utils import admin, test_user, test_user1, \
-                  test_user2, test_user3, test_user4, test_user5
+                  test_user2, test_user3, test_user4, test_user5, test_student
 
 pre_config = os.environ.get('FLASK_CONFIGURATION', None)
 
@@ -32,6 +32,8 @@ def client():
     id_list = load_id_json_file(json_path)
     admin_cred = next(i for i in id_list if i['authority'] == 'admin')
     admin['secret_id'] = admin_cred['secret_id']
+    student_cred = next(i for i in id_list if i['kind'] == 'student')
+    test_student['secret_id'] = student_cred['secret_id']
     test_creds = (i for i in id_list if i['authority'] != 'admin')
     for user in [test_user, test_user1, test_user2, test_user3,
                  test_user4, test_user5]:

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -177,7 +177,8 @@ def test_auth_used_user(client):
                     return_value=date_login):
         resp = client.post('/auth', json={
                            'id': login_user['secret_id'],
-                           'g-recaptcha-response': login_user['g-recaptcha-response']
+                           'g-recaptcha-response':
+                               login_user['g-recaptcha-response']
                            }, follow_redirects=True)
 
     assert resp.status_code == 400

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest import mock
 from datetime import date
 from utils import (
@@ -186,7 +185,6 @@ def test_auth_used_user(client):
     assert resp.get_json()['message'] == 'Login Unsuccessful'
 
 
-@pytest.mark.skip(reason="field 'kind' is not added yet")
 def test_auth_overtime_as_student(client):
     """attempt to use same `user`(which isn't in ONE_DAY_KIND) for 2 days
     target_url: /auth

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -5,7 +5,8 @@ from utils import (
     login_with_form,
     login,
     admin,
-    test_user
+    test_user,
+    test_student
 )
 from api.models import User, db
 from api.schemas import user_schema

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -166,8 +166,8 @@ def test_auth_used_user(client):
         target_url: /auth
     """
     login_user = test_user
-    date_before = date(2018, 1, 1)
-    date_login = date(2018, 1, 2)
+    date_before = date(2038, 1, 1)
+    date_login = date(2038, 1, 2)
     with client.application.app_context():
         user = User.query.filter_by(secret_id=login_user['secret_id']).first()
         user.first_access = date_before

--- a/test/utils.py
+++ b/test/utils.py
@@ -17,6 +17,8 @@ test_user4 = {'secret_id': '',
               'g-recaptcha-response': ''}
 test_user5 = {'secret_id': '',
               'g-recaptcha-response': ''}
+test_student = {'secret_id': '',
+                'g-recaptcha-response': ''}
 
 invalid_classroom_id = '999999999999'
 invalid_lottery_id = '9999999999'


### PR DESCRIPTION
~~**未完成です margeしないでください**~~
~~=====================================~~
~~正確にいえば未完成なことが発覚しました。~~

Todo
-----
  - [x] 生徒用の`user id`を判別する
  - [x] 生徒用の`user id`の場合は、`first-access`にかかわらず通すようにする

  * OS: Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
  * devenv: c4618a6eb4628bc1b1e3c5d75a76d4dda5664ea5
  * frontend: bc0fbefda7bd3312428acba83ed05937f9049e3d
  * backend: c4618a6eb4628bc1b1e3c5d75a76d4dda5664ea5

変更内容
================

  * 1日目に使用された`user id`を2日目では使用不可能にします。
  * これは、二日間とも来場した人が、二つの`user id`を使用できてしまうことを防ぐ為にあります。
  * 正確には、**違う日付に使用された`user id`は無効化する**内容となります。
    そのため、例えば作展が3日に拡大した場合も、1,2日目に使用された`user
    id`は3日目には無効化されます。

  * 無効化された`user id`がtokenに使われていた場合、`backend`は`401 -- unauthorized`を返します。`realm`は`id_disabled`です。
  * 無効化された`user id`が団体応募のメンバーに入っていた場合、`backend`は`401 -- Invalid group member secret id`を返します。これは、メンバーのidが不正だった場合と同じものです。
  * #78

修正前の挙動:
-------------

  * 日付が変わっても、同じ`user id`及び`secret_id`、`public_id`を使うことができた

修正後の挙動:
-------------

  * 日付が変わると、同じ`user id`及び`secret_id`、`public_id`を使うことができない

影響範囲
================

  * 特になし