### PR TITLE
落選者優先の確率変動

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ pytest = "*"
 watchdog = "*"
 pillow = "*"
 qrcode = "*"
+numpy = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b373d04c416324fe654aea10f187851db5dd677afcedc6a301be4780d90bb92a"
+            "sha256": "39b42dbfd728c79d5108fa1bb0edc7a43ce8dc880c15cf6e690279d63418cffd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,10 +32,11 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:6b5282987b21cd79151f51caccead7a09d0a32e89c568bd9e3c4aaa7bbdf3f3a",
+                "sha256:e16334d50fe0f90919ef7339c24b9b62e6abaa78cd2d226f3d94eb067eb89043"
             ],
-            "version": "==1.1.5"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==1.2.0"
         },
         "attrs": {
             "hashes": [
@@ -90,28 +91,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
-                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
-                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
-                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
-                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
-                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
-                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
-                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
-                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
-                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
-                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
-                "sha256:87d092a7c2a44e5f7414ab02fb4145723ebba411425e1a99773531dd4c0e9b8d",
-                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
-                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
-                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
-                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6",
-                "sha256:c3d945b7b577f07a477700f618f46cbc287af3a9222cd73035c6ef527ef2c363",
-                "sha256:cee18beb4c807b5c0b178f4fa2fae03cef9d51821a358c6890f8b23465b7e5d2",
-                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90"
+                "sha256:02602e1672b62e803e08617ec286041cc453e8d43f093a5f4162095506bc0beb",
+                "sha256:10b48e848e1edb93c1d3b797c83c72b4c387ab0eb4330aaa26da8049a6cbede0",
+                "sha256:17db09db9d7c5de130023657be42689d1a5f60502a14f6f745f6f65a6b8195c0",
+                "sha256:227da3a896df1106b1a69b1e319dce218fa04395e8cc78be7e31ca94c21254bc",
+                "sha256:2cbaa03ac677db6c821dac3f4cdfd1461a32d0615847eedbb0df54bb7802e1f7",
+                "sha256:31db8febfc768e4b4bd826750a70c79c99ea423f4697d1dab764eb9f9f849519",
+                "sha256:4a510d268e55e2e067715d728e4ca6cd26a8e9f1f3d174faf88e6f2cb6b6c395",
+                "sha256:6a88d9004310a198c474d8a822ee96a6dd6c01efe66facdf17cb692512ae5bc0",
+                "sha256:76936ec70a9b72eb8c58314c38c55a0336a2b36de0c7ee8fb874a4547cadbd39",
+                "sha256:7e3b4aecc4040928efa8a7cdaf074e868af32c58ffc9bb77e7bf2c1a16783286",
+                "sha256:8168bcb08403ef144ff1fb880d416f49e2728101d02aaadfe9645883222c0aa5",
+                "sha256:8229ceb79a1792823d87779959184a1bf95768e9248c93ae9f97c7a2f60376a1",
+                "sha256:8a19e9f2fe69f6a44a5c156968d9fc8df56d09798d0c6a34ccc373bb186cee86",
+                "sha256:8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6",
+                "sha256:be495b8ec5a939a7605274b6e59fbc35e76f5ad814ae010eb679529671c9e119",
+                "sha256:dc2d3f3b1548f4d11786616cf0f4415e25b0fbecb8a1d2cd8c07568f13fdde38",
+                "sha256:e4aecdd9d5a3d06c337894c9a6e2961898d3f64fe54ca920a72234a3de0f9cb3",
+                "sha256:e79ab4485b99eacb2166f3212218dd858258f374855e1568f728462b0e6ee0d9",
+                "sha256:f995d3667301e1754c57b04e0bae6f0fa9d710697a9f8d6712e8cca02550910f"
             ],
             "index": "pypi",
-            "version": "==2.3"
+            "version": "==2.3.1"
         },
         "flasgger": {
             "hashes": [
@@ -188,11 +189,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:171f409d48b44786b7df2793cbd7f1a9062f0fe2c14d547da536b5010f671ade",
-                "sha256:c231784b5a5d2b26e50c90f3038004a3552ec27658cde6e0a5a7279d0c5a8e26"
+                "sha256:0f3776aa5b5405f6000c9304841abe6d4d708bb08207fc89a5ecd86622ec9e54",
+                "sha256:57a107cfd58e9ed52dd355c65444e983d064fdcf63214a487d7305a2d24680db"
             ],
             "index": "pypi",
-            "version": "==2.15.3"
+            "version": "==2.15.4"
         },
         "mistune": {
             "hashes": [
@@ -203,11 +204,45 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:1c362ad12dd09a43b348bb28dd2295dd9cdf77f41f0f45965e04ba97f525b864",
+                "sha256:2156a06bd407918df4ac0122df6497a9c137432118f585e5b17d543e593d1587",
+                "sha256:24e4149c38489b51fc774b1e1faa9103e82f73344d7a00ba66f6845ab4769f3f",
+                "sha256:340ec1697d9bb3a9c464028af7a54245298502e91178bddb4c37626d36e197b7",
+                "sha256:35db8d419345caa4eeaa65cd63f34a15208acd87530a30f0bc25fc84f55c8c80",
+                "sha256:361370e9b7f5e44c41eee29f2bb5cb3b755abb4b038bce6d6cbe08db7ff9cb74",
+                "sha256:36e8dcd1813ca92ce7e4299120cee6c03adad33d89b54862c1b1a100443ac399",
+                "sha256:378378973546ecc1dfaf9e24c160d683dd04df871ecd2dcc86ce658ca20f92c0",
+                "sha256:419e6faee16097124ee627ed31572c7e80a1070efa25260b78097cca240e219a",
+                "sha256:4287104c24e6a09b9b418761a1e7b1bbde65105f110690ca46a23600a3c606b8",
+                "sha256:549f3e9778b148a47f4fb4682955ed88057eb627c9fe5467f33507c536deda9d",
+                "sha256:5e359e9c531075220785603e5966eef20ccae9b3b6b8a06fdfb66c084361ce92",
+                "sha256:5ee7f3dbbdba0da75dec7e94bd7a2b10fe57a83e1b38e678200a6ad8e7b14fdc",
+                "sha256:62d55e96ec7b117d3d5e618c15efcf769e70a6effaee5842857b64fb4883887a",
+                "sha256:719b6789acb2bc86ea9b33a701d7c43dc2fc56d95107fd3c5b0a8230164d4dfb",
+                "sha256:7a70f2b60d48828cba94a54a8776b61a9c2657a803d47f5785f8062e3a9c7c55",
+                "sha256:7b9e37f194f8bcdca8e9e6af92e2cbad79e360542effc2dd6b98d63955d8d8a3",
+                "sha256:83b8fc18261b70f45bece2d392537c93dc81eb6c539a16c9ac994c47fc79f09a",
+                "sha256:9473ad28375710ab18378e72b59422399b27e957e9339c413bf00793b4b12df0",
+                "sha256:95b085b253080e5d09f7826f5e27dce067bae813a132023a77b739614a29de6e",
+                "sha256:98b86c62c08c2e5dc98a9c856d4a95329d11b1c6058cb9b5191d5ea6891acd09",
+                "sha256:a3bd01d6d3ed3d7c06d7f9979ba5d68281f15383fafd53b81aa44b9191047cf8",
+                "sha256:c81a6afc1d2531a9ada50b58f8c36197f8418ef3d0611d4c1d7af93fdcda764f",
+                "sha256:ce75ed495a746e3e78cfa22a77096b3bff2eda995616cb7a542047f233091268",
+                "sha256:dae8618c0bcbfcf6cf91350f8abcdd84158323711566a8c5892b5c7f832af76f",
+                "sha256:df0b02c6705c5d1c25cc35c7b5d6b6f9b3b30833f9d178843397ae55ecc2eebb",
+                "sha256:e3660744cda0d94b90141cdd0db9308b958a372cfeee8d7188fdf5ad9108ea82",
+                "sha256:f2362d0ca3e16c37782c1054d7972b8ad2729169567e3f0f4e5dd3cdf85f188e"
+            ],
+            "index": "pypi",
+            "version": "==1.15.1"
         },
         "pathtools": {
             "hashes": [
@@ -253,11 +288,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
-                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "version": "==0.6.0"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==0.7.1"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -297,10 +332,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "version": "==1.5.4"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==1.6.0"
         },
         "pycparser": {
             "hashes": [
@@ -310,11 +346,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
-                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
+                "sha256:2e7c330338b2732ddb992217962e3454aa7290434e75329b1a6739cea41bea6b",
+                "sha256:4abcd98faeea3eb95bd05aa6a7b121d5f89d72e4d36ddb0dcbbfd1ec9f3651d1"
             ],
             "index": "pypi",
-            "version": "==3.6.3"
+            "version": "==3.7.3"
         },
         "pyyaml": {
             "hashes": [
@@ -350,16 +386,16 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
+                "sha256:ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524"
             ],
-            "version": "==1.2.10"
+            "version": "==1.2.11"
         },
         "watchdog": {
             "hashes": [
-                "sha256:7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162"
+                "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
             ],
             "index": "pypi",
-            "version": "==0.8.3"
+            "version": "==0.9.0"
         },
         "werkzeug": {
             "hashes": [

--- a/api/draw.py
+++ b/api/draw.py
@@ -166,6 +166,12 @@ def draw_all_at_index(index):
 
 
 def calc_probabilities(applications):
+    """
+        calculate the probability of each application
+        return list of the weight of each application showing how likely
+        the application is to be chosen in comparison with others
+        the sum of the list is 1
+    """
     sum_advantage = sum(app.advantage for app in applications)
     return [app.advantage / sum_advantage for app in applications]
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -34,7 +34,9 @@ def draw_one(lottery):
         winners = []
     else:
         for app in applications:
-            app.advantage = calc_advantage(app)     # set a new field
+            # set a new field
+            app.advantage = calc_advantage(
+                app.user.win_count, app.user.lose_count)
 
         winners_num = current_app.config['WINNERS_NUM']
 
@@ -176,13 +178,11 @@ def calc_probabilities(applications):
     return [app.advantage / sum_advantage for app in applications]
 
 
-def calc_advantage(app):
+def calc_advantage(win_count, lose_count):
     """
         returns multiplier indicating how more likely
         the application is to win
     """
-    win_count = app.user.win_count
-    lose_count = app.user.lose_count
     if win_count == 0 and lose_count == 0:
         return 1
     else:

--- a/api/draw.py
+++ b/api/draw.py
@@ -34,7 +34,7 @@ def draw_one(lottery):
         winners = []
     else:
         for app in applications:
-            app.advantage = calc_advantage(app)
+            app.advantage = calc_advantage(app)     # set a new field
 
         winners_num = current_app.config['WINNERS_NUM']
 

--- a/api/draw.py
+++ b/api/draw.py
@@ -179,4 +179,4 @@ def calc_advantage(app):
     if win_count == 0 and lose_count == 0:
         return 1
     else:
-        return 1    # TODO: DEFINE ME please!
+        return lose_count   # TODO: DEFINE ME please!

--- a/api/draw.py
+++ b/api/draw.py
@@ -86,16 +86,17 @@ def draw_one_group_members(applications, winners_num):
         for member in rep.group_members:
             from_apps.remove(member.own_application)
 
-    reps = [app for app in applications if app.is_rep]
-    indexes = [i for i, app in enumerate(applications) if app.is_rep]
+    reps_with_index = [(i, app)
+                       for i, app in enumerate(applications) if app.is_rep]
 
     all_probabilities = calc_probabilities(applications)
 
-    for i, rep in zip(indexes, reps):
+    for i, rep in reps_with_index:
         set_group_result(rep,
                          random.random() < all_probabilities[i] * winners_num)
 
-    n_group_members = sum(len(rep_app.group_members) + 1 for rep_app in reps)
+    n_group_members = sum(len(rep_app.group_members) + 1
+                          for _, rep_app in reps_with_index)
     n_normal_users = len(applications) - n_group_members
 
     # when too few groups accidentally won

--- a/api/models.py
+++ b/api/models.py
@@ -21,8 +21,8 @@ class User(db.Model):
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
-    win_count = db.Column(db.Integer)
-    lose_count = db.Column(db.Integer)
+    win_count = db.Column(db.Integer, default=0)
+    lose_count = db.Column(db.Integer, default=0)
 
     def __repr__(self):
         authority_str = f'({self.authority})' if self.authority else ''
@@ -90,7 +90,6 @@ class Application(db.Model):
             user_id (int): user id of this application
             status (Boolen): whether chosen or not. initalized with None
             is_rep (bool): whether rep of a group or not
-            probabitily (nullable float): how likely the application is to win
     """
     __tablename__ = 'application'
     __table_args__ = (UniqueConstraint(
@@ -108,7 +107,6 @@ class Application(db.Model):
                        default="pending",
                        nullable=False)
     is_rep = db.Column(db.Boolean, default=False)
-    probabitily = db.Column(db.Float, default=None)
 
     def __repr__(self):
         return "<Application {}{}{} {}>".format(

--- a/api/models.py
+++ b/api/models.py
@@ -14,12 +14,14 @@ class User(db.Model):
         DB contents:
             public_id (int): public id.
             secret_id (int): secret id.
+            win_count (int): how many times the user won
             lose_count (int): how many times the user lost
     """
     id = db.Column(db.Integer, primary_key=True)
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
+    win_count = db.Column(db.Integer)
     lose_count = db.Column(db.Integer)
 
     def __repr__(self):

--- a/api/models.py
+++ b/api/models.py
@@ -90,6 +90,7 @@ class Application(db.Model):
             user_id (int): user id of this application
             status (Boolen): whether chosen or not. initalized with None
             is_rep (bool): whether rep of a group or not
+            probabitily (nullable float): how likely the application is to win
     """
     __tablename__ = 'application'
     __table_args__ = (UniqueConstraint(
@@ -107,6 +108,7 @@ class Application(db.Model):
                        default="pending",
                        nullable=False)
     is_rep = db.Column(db.Boolean, default=False)
+    probabitily = db.Column(db.Float, default=None)
 
     def __repr__(self):
         return "<Application {}{}{} {}>".format(

--- a/api/models.py
+++ b/api/models.py
@@ -14,15 +14,18 @@ class User(db.Model):
         DB contents:
             public_id (int): public id.
             secret_id (int): secret id.
+            lose_count (int): how many times the user lost
     """
     id = db.Column(db.Integer, primary_key=True)
     public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
+    lose_count = db.Column(db.Integer)
 
     def __repr__(self):
         authority_str = f'({self.authority})' if self.authority else ''
-        return f'<User {encode_public_id(self.public_id)} {authority_str}>'
+        return f'<User ({self.lose_count}) ' \
+               f'{encode_public_id(self.public_id)} {authority_str}>'
 
 
 class Classroom(db.Model):

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -7,6 +7,8 @@ class UserSchema(Schema):
     id = fields.Int(dump_only=True)
     secret_id = fields.Str()
     public_id = fields.Method("get_public_id_str", dump_only=True)
+    win_count = fields.Int()
+    lose_count = fields.Int()
 
     def get_public_id_str(self, user):
         return encode_public_id(user.public_id)


### PR DESCRIPTION
 * OS: Linux masato-laptop 4.15.0-33-generic #36-Ubuntu SMP Wed Aug 15 16:00:05 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * devenv: 3c7149cce36dbdaa611a642d4aedd97ea86028c1
 * frontend: bc0fbefda7bd3312428acba83ed05937f9049e3d
 * backend: 115d57e95fea42a25b8362fcb46084e29d7ad8f2


変更内容
================

**落選者優先の確率変動** #4
※どれだけ変動させるかは***仮に***
```n回落選した人（n ≠ 0）は落選０の応募者のn倍の確率で当たる
```としてあります。

* `numpy`ライブラリの導入
* `random.sample()`から`numpy.random.choice()`への移行
    - `sample()`は均等な確率で抜き出すが、`choice()`では各要素がそれぞれユーザー指定の確率で抜き出される
* `User`データベースに`win_count (int)`、`lose_count (int)`を導入（デフォルトで`0`）
* それに伴うschemaの更新
* `calc_advantage(win_count, lose_count)`の「初回応募のx倍の確率」という形式での確率変動の定義
* *代表者の確率変動*を基準にしたグループ応募の確率変動

修正後の挙動:
-------------

* 負けの回数が多い人ほど多く当選します。
具体的には、`User(id=1)`のみ`lose_count`を`3`とした上で
上記の確率変動幅で応募者6人、当選者3人で20回回すと
```python
{1: 18, 2: 10, 3: 7, 4: 8, 5: 12, 6: 5}
```となりました。
* 確率の変動の定義である`calc_advantage(win_count, lose_count)`を利用すれば、
逆に「何度も当たっている人の確率を下げる」ようなこともできます（今はしてません）

影響範囲
================
  * 今までの形式のコードが動かなくなることはありません
  * `numpy`の関数が利用できるようになります
[`argmax`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmax.html)のような地味に便利な関数も割とあります