### PR TITLE
checker用API`/checker/{classroom_id}/{secret_id}`の追加-#61

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -105,9 +105,9 @@ class Application(db.Model):
 
     def __repr__(self):
         return "<Application {}{}{} {}>".format(
-                                            self.lottery, self.user,
-                                            " (rep)" if self.is_rep else "",
-                                            self.status)
+            self.lottery, self.user,
+            " (rep)" if self.is_rep else "",
+            self.status)
 
 
 class GroupMember(db.Model):
@@ -121,9 +121,9 @@ class GroupMember(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(
-            db.Integer,
-            db.ForeignKey('user.id', ondelete='CASCADE'),
-            db.ForeignKey('application.user_id', ondelete='CASCADE'))
+        db.Integer,
+        db.ForeignKey('user.id', ondelete='CASCADE'),
+        db.ForeignKey('application.user_id', ondelete='CASCADE'))
     user = db.relationship('User')
     own_application = db.relationship('Application',
                                       foreign_keys=[user_id],

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -142,7 +142,7 @@ def apply_lottery(idx):
                    app.lottery.id != lottery.id
                    for app in previous.all()):
                 msg = "someone in the group is already " \
-                       "applying to a lottery in this period"
+                    "applying to a lottery in this period"
                 return jsonify({"message": msg}), 400
             if any(app.lottery.index == lottery.index and
                    app.lottery.id == lottery.id
@@ -371,4 +371,3 @@ def checker(classroom_id, secret_id):
         return jsonify({"message": "application not found"}), 404
 
     return jsonify({"status": application.status})
-

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -347,3 +347,28 @@ def translate_secret_to_public(secret_id):
         return jsonify({"message": "no such user found"}), 404
     else:
         return jsonify({"public_id": user.public_id})
+
+
+@bp.route('/checker/<int:classroom_id>/<string:secret_id>', methods=['GET'])
+@spec('api/checker.yml')
+@login_required('checker')
+def checker(classroom_id, secret_id):
+    """return if the user is winner of given classroom
+        Args:
+            classroom_id (int): target classroom
+            secret_id (string): secret id of target user
+    """
+    user = User.query.filter_by(secret_id=secret_id).first()
+    if not user:
+        return jsonify({"message": "user not found"}), 404
+    lottery = Lottery.query.filter_by(classroom_id=classroom_id,
+                                      index=get_time_index)
+    if not lottery:
+        return jsonify({"message": "lottery not found"}), 404
+    application = Application.query.filter_by(user=user,
+                                              lottery=lottery).first()
+    if not application:
+        return jsonify({"message": "application not found"}), 404
+
+    return jsonify({"status": application.status})
+

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -361,10 +361,12 @@ def checker(classroom_id, secret_id):
     user = User.query.filter_by(secret_id=secret_id).first()
     if not user:
         return jsonify({"message": "user not found"}), 404
+    try:
+        index = get_time_index()
+    except (OutOfHoursError, OutOfAcceptingHoursError):
+        return jsonify({"message": "Not acceptable time"}), 400
     lottery = Lottery.query.filter_by(classroom_id=classroom_id,
-                                      index=get_time_index()).first()
-    if not lottery:
-        return jsonify({"message": "lottery not found"}), 404
+                                      index=index).first()
     application = Application.query.filter_by(user=user,
                                               lottery=lottery).first()
     if not application:

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -362,7 +362,7 @@ def checker(classroom_id, secret_id):
     if not user:
         return jsonify({"message": "user not found"}), 404
     lottery = Lottery.query.filter_by(classroom_id=classroom_id,
-                                      index=get_time_index)
+                                      index=get_time_index()).first()
     if not lottery:
         return jsonify({"message": "lottery not found"}), 404
     application = Application.query.filter_by(user=user,

--- a/api/spec/routes/api/checker.yml
+++ b/api/spec/routes/api/checker.yml
@@ -47,4 +47,9 @@ response:
     description: user not found / lottery not found / application not found
     schema:
       $ref: '#/definitions/ErrorMessage'
-
+security:
+  - checker_auth: []
+tags:
+  - checker
+description: check the user status for lottery of the classroom
+operationId: checkStatus

--- a/api/spec/routes/api/checker.yml
+++ b/api/spec/routes/api/checker.yml
@@ -16,7 +16,7 @@ parameters:
     required: true
 response:
   '200':
-    description:  'status' of the application
+    description:  status of the application
     schema:
       properties:
         status:

--- a/api/spec/routes/api/checker.yml
+++ b/api/spec/routes/api/checker.yml
@@ -1,0 +1,50 @@
+checker endpoint.
+check user's status for that classroom.
+---
+produces:
+  - application/json
+parameters:
+  - description: classroom's id to check.
+    in: path
+    type: int
+    name: classroom_id
+    required: true
+  - description: secret_id of visitor
+    in: path
+    type: string
+    name: secret_id
+    required: true
+response:
+  '200':
+    description:  'status' of the application
+    schema:
+      properties:
+        status:
+          description: the status. can be ["won"|"lose"|"pending"]
+          type: string
+  '400':
+    description: Malformed Authenication Header has detected
+    headers:
+      WWW-Authenticate:
+        description: >-
+          Authenication Error Code. For details, please refer to RFC 6750
+          3. The WWW-Authenticate Response Header Field
+        type: string
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+  '401':
+    description: Authorization Failed
+    headers:
+      WWW-Authenticate:
+        description: >-
+          Authenication Error Code. For details, please refer to RFC 6750
+          3. The WWW-Authenticate Response Header Field
+        type: string
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+
+  '404':
+    description: user not found / lottery not found / application not found
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+

--- a/api/spec/routes/api/checker.yml
+++ b/api/spec/routes/api/checker.yml
@@ -23,7 +23,7 @@ response:
           description: the status. can be ["won"|"lose"|"pending"]
           type: string
   '400':
-    description: Malformed Authenication Header has detected
+    description: Malformed Authenication Header has detected / Not acceptable time
     headers:
       WWW-Authenticate:
         description: >-
@@ -44,7 +44,7 @@ response:
       $ref: '#/definitions/ErrorMessage'
 
   '404':
-    description: user not found / lottery not found / application not found
+    description: user not found  / application not found
     schema:
       $ref: '#/definitions/ErrorMessage'
 security:

--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -47,7 +47,7 @@
     {
         "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",
         "public_id": "6JGL",
-        "authority": "normal"
+        "authority": "checker"
     },
     {
         "secret_id": "GfVf96Ns9-NW9WI_Kc5KE8D4J4-ega9w",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,7 @@ sys.path.append(os.getcwd())  # noqa: E402
 from api import app
 from cards.id import load_id_json_file
 
-from utils import admin, test_user, test_user1, \
+from utils import admin, checker, test_user, test_user1, \
                   test_user2, test_user3, test_user4, test_user5
 
 pre_config = os.environ.get('FLASK_CONFIGURATION', None)
@@ -32,6 +32,8 @@ def client():
     id_list = load_id_json_file(json_path)
     admin_cred = next(i for i in id_list if i['authority'] == 'admin')
     admin['secret_id'] = admin_cred['secret_id']
+    checker_cred = next(i for i in id_list if i['authority'] == 'checker')
+    checker['secret_id'] = checker_cred['secret_id']
     test_creds = (i for i in id_list if i['authority'] != 'admin')
     for user in [test_user, test_user1, test_user2, test_user3,
                  test_user4, test_user5]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ from api import app
 from cards.id import load_id_json_file
 
 from utils import admin, checker, test_user, test_user1, \
-                  test_user2, test_user3, test_user4, test_user5
+    test_user2, test_user3, test_user4, test_user5
 
 pre_config = os.environ.get('FLASK_CONFIGURATION', None)
 

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -1,0 +1,31 @@
+from unittest import mock
+import pytest
+from utils import test_user
+from api.models import Lottery, User, Application, db
+
+
+@pytest.mark.parametrize("def_status", ["pending", "won", "lose"])
+def test_checker(client, def_status):
+    """use `/checker` endpoint with winner user
+        target_url: /checker/{classroom_id}/{secret_id}
+    """
+    classroom_id = 1
+    index = 1
+    target_user = test_user
+    secret_id = target_user['secret_id']
+
+    with client.application.app_context():
+        lottery_id = Lottery.query.filter_by(classroom_id=classroom_id,
+                                             index=index).first().id
+        user = User.query.filter_by(secret_id=secret_id).first()
+        application = Application(user_id=user.id,
+                                  lottery_id=lottery_id, status=def_status)
+        db.session.add(application)
+        db.session.commit()
+
+    with mock.patch('api.routes.api.get_time_index',  # is that correct?
+                    return_value=1):
+        resp = client.get(f'/checker/{classroom_id}/{secret_id}')
+
+    assert resp.status == 200
+    assert resp.get_json()['status'] == def_status  # This is still not sure

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -25,7 +25,7 @@ def test_checker(client, def_status):
         db.session.commit()
 
     with mock.patch('api.routes.api.get_time_index',  # is that correct?
-                    return_value=1):
+                    return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],
                            f'/checker/{classroom_id}/{secret_id}')

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -24,7 +24,7 @@ def test_checker(client, def_status):
         db.session.add(application)
         db.session.commit()
 
-    with mock.patch('api.routes.api.get_time_index',  # is that correct?
+    with mock.patch('api.routes.api.get_time_index',
                     return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],
@@ -34,7 +34,7 @@ def test_checker(client, def_status):
     assert resp.get_json()['status'] == def_status
 
 
-def test_checker_no_application(client):  # This is still not sure
+def test_checker_no_application(client):
     """attempt to use `/checker` endpoint without application for that
        target_url: /checker/{classroom_id}/{secret_id}
     """
@@ -44,7 +44,7 @@ def test_checker_no_application(client):  # This is still not sure
     secret_id = target_user['secret_id']
     staff = checker
 
-    with mock.patch('api.routes.api.get_time_index',  # is that correct?
+    with mock.patch('api.routes.api.get_time_index',
                     return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -26,7 +26,9 @@ def test_checker(client, def_status):
 
     with mock.patch('api.routes.api.get_time_index',  # is that correct?
                     return_value=1):
-        resp = client.get(f'/checker/{classroom_id}/{secret_id}')
+        resp = as_user_get(client, staff['secret_id'],
+                           staff['g-recaptcha-response'],
+                           f'/checker/{classroom_id}/{secret_id}')
 
     assert resp.status == 200
     assert resp.get_json()['status'] == def_status  # This is still not sure

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -30,5 +30,5 @@ def test_checker(client, def_status):
                            staff['g-recaptcha-response'],
                            f'/checker/{classroom_id}/{secret_id}')
 
-    assert resp.status == 200
-    assert resp.get_json()['status'] == def_status  # This is still not sure
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == def_status

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -32,3 +32,22 @@ def test_checker(client, def_status):
 
     assert resp.status_code == 200
     assert resp.get_json()['status'] == def_status
+
+
+def test_checker_no_application(client):  # This is still not sure
+    """attempt to use `/checker` endpoint without application for that
+       target_url: /checker/{classroom_id}/{secret_id}
+    """
+    classroom_id = 1
+    index = 1
+    target_user = test_user
+    secret_id = target_user['secret_id']
+    staff = checker
+
+    with mock.patch('api.routes.api.get_time_index',  # is that correct?
+                    return_value=index):
+        resp = as_user_get(client, staff['secret_id'],
+                           staff['g-recaptcha-response'],
+                           f'/checker/{classroom_id}/{secret_id}')
+    assert resp.status_code == 404
+    assert resp.get_json()['message'] == 'application not found'

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -1,6 +1,6 @@
 from unittest import mock
 import pytest
-from utils import test_user
+from utils import test_user, checker, as_user_get
 from api.models import Lottery, User, Application, db
 
 
@@ -12,6 +12,7 @@ def test_checker(client, def_status):
     classroom_id = 1
     index = 1
     target_user = test_user
+    staff = checker
     secret_id = target_user['secret_id']
 
     with client.application.app_context():

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -51,3 +51,21 @@ def test_checker_no_application(client):  # This is still not sure
                            f'/checker/{classroom_id}/{secret_id}')
     assert resp.status_code == 404
     assert resp.get_json()['message'] == 'application not found'
+
+
+def test_checker_invalid_user(client):
+    """attempt to use `/checker` endpoint with wrong user
+    """
+    classroom_id = 1
+    index = 1
+    staff = checker
+    secret_id = "NOTEXIST_SECRET_KEY"
+
+    with mock.patch('api.routes.api.get_time_index',
+                    return_value=index):
+        resp = as_user_get(client, staff['secret_id'],
+                           staff['g-recaptcha-response'],
+                           f'/checker/{classroom_id}/{secret_id}')
+
+    assert resp.status_code == 404
+    assert resp.get_json()['message'] == 'user not found'

--- a/test/utils.py
+++ b/test/utils.py
@@ -5,6 +5,8 @@ from api.models import User, Application, db
 # secret_id is to be set in the fixture
 admin = {'secret_id': '',
          'g-recaptcha-response': ''}
+checker = {'secret_id': '',
+           'g-recaptcha-response': ''}
 test_user = {'secret_id': '',
              'g-recaptcha-response': ''}
 test_user1 = {'secret_id': '',


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

 * OS: Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0:
Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * devenv: 3c7149cce36dbdaa611a642d4aedd97ea86028c1
 * frontend: bc0fbefda7bd3312428acba83ed05937f9049e3d
 * backend: 567060b297f7c1b79f88b928218ca48013ef065b

変更内容
================

  * 実際に各クラスにて受付するスタッフ(checker)用のAPIです。
  * `classroom_id`と、来場者の`secret_id`を投げると、その`classroom`のその時刻の`lottery`へのその人の`application`の状態を返します。
  * もしもそのユーザーがその`lottery`に応募していなかった場合、`404 -- application not found`が返されます。
  * ユーザーが存在しなかった場合`404 -- user not found`が返されます。
  * `lottery`が存在しなかった場合`400 -- Not acceptable time `が返されます。これは、時間外で`lottery`が存在しなかった時にのみ返されます。
  * #61

修正前の挙動:
-------------

  * `/checker`エンドポイントがなかった

修正後の挙動:
-------------

  * `/checker`エンドポイントができた