### PR TITLE
`/public_id`エンドポイントのspecに`security`を追加

### DIFF
--- a/api/spec/routes/api/translate_secret_to_public.yml
+++ b/api/spec/routes/api/translate_secret_to_public.yml
@@ -22,3 +22,7 @@ responses:
       $ref: '#/definitions/ErrorMessage'
 tags:
   - user
+security:
+  - user_auth: []
+  - admin_auth: []
+  - checker_auth: []


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

変更内容
================

  * `/public_id`のspecに`security`が抜けていたので追加しました
  * #146

修正前の挙動:
-------------

  * `/public_id`のリファレンスが間違っていた

修正後の挙動:
-------------

  * `/public_id`のリファレンスが正しくなった