### PR TITLE
Manage errors using error codes

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -133,7 +133,7 @@ def generate():
     with open(json_path, 'r') as f:
         error_list = json.load(f)
     for (code, message) in error_list.items():
-        error = Error(code=code, message=message)
+        error = Error(code=int(code, 10), message=message)
         db.session.add(error)
 
     db.session.commit()

--- a/api/app.py
+++ b/api/app.py
@@ -128,3 +128,12 @@ def generate():
         db.session.add(user)
 
     db.session.commit()
+
+    json_path = current_app.config['ERROR_TABLE_FILE']
+    with open(json_path, 'r') as f:
+        error_list = json.load(f)
+    for (code, message) in error_list.items():
+        error = Error(code=code, message=message)
+        db.session.add(error)
+
+    db.session.commit()

--- a/api/app.py
+++ b/api/app.py
@@ -132,8 +132,8 @@ def generate():
     json_path = current_app.config['ERROR_TABLE_FILE']
     with open(json_path, 'r') as f:
         error_list = json.load(f)
-    for (code, message) in error_list.items():
-        error = Error(code=int(code, 10), message=message)
+    for (code, desc) in error_list.items():
+        error = Error(code=int(code, 10), message=desc['message'], http_code=desc['status'])
         db.session.add(error)
 
     db.session.commit()

--- a/api/app.py
+++ b/api/app.py
@@ -134,7 +134,8 @@ def generate():
     with open(json_path, 'r') as f:
         error_list = json.load(f)
     for (code, desc) in error_list.items():
-        error = Error(code=int(code, 10), message=desc['message'], http_code=desc['status'])
+        error = Error(code=int(code, 10),
+                      message=desc['message'], http_code=desc['status'])
         db.session.add(error)
 
     db.session.commit()

--- a/api/app.py
+++ b/api/app.py
@@ -7,6 +7,7 @@ from .models import db
 from cards.id import load_id_json_file, decode_public_id
 import os
 import sys
+import json
 
 config = {
     "development": "api.config.DevelopmentConfig",
@@ -93,7 +94,7 @@ def generate():
         Return:
             no-return given
     """
-    from .models import Lottery, Classroom, User, db
+    from .models import Lottery, Classroom, User, Error, db
     total_index = 4
     grades = [5, 6]
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -7,6 +7,7 @@ import json
 from api.time_management import get_current_datetime
 from api.error import error_response
 
+
 def generate_token(obj):
     """
         generate token and expiration, return it.

--- a/api/auth.py
+++ b/api/auth.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from functools import wraps
 import json
 from api.time_management import get_current_datetime
-
+from api.error import error_response
 
 def generate_token(obj):
     """

--- a/api/auth.py
+++ b/api/auth.py
@@ -59,7 +59,7 @@ def login_required(*required_authority):
             time = get_current_datetime()
             end = current_app.config['END_DATETIME']
             if end <= time:
-                return auth_error(15, 'realm="not acceptable"')
+                return auth_error(18, 'realm="not acceptable"')
 
             # check form of request header
             if 'Authorization' not in request.headers:

--- a/api/auth.py
+++ b/api/auth.py
@@ -51,15 +51,7 @@ def login_required(*required_authority):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             def auth_error(code, headm=None):
-                if code == 400:
-                    message = 'Invalid Request'
-                elif code == 401:
-                    message = 'Unauthorized'
-                elif code == 403:
-                    message = 'Forbidden'
-                else:
-                    message = 'Unknown Error'
-                resp = make_response(jsonify({"message": message}), code)
+                resp = error_response(code)
                 if headm:
                     resp.headers['WWW-Authenticate'] = 'Bearer ' + headm
                 return resp
@@ -67,26 +59,26 @@ def login_required(*required_authority):
             time = get_current_datetime()
             end = current_app.config['END_DATETIME']
             if end <= time:
-                return auth_error(403, 'realm="not acceptable"')
+                return auth_error(15, 'realm="not acceptable"')
 
             # check form of request header
             if 'Authorization' not in request.headers:
-                return auth_error(401, 'realm="token_required"')
+                return auth_error(0, 'realm="token_required"')
             auth = request.headers['Authorization'].split()
             if auth[0].lower() != 'bearer':
-                return auth_error(400, 'error="invalid_request"')
+                return auth_error(4, 'error="invalid_request"')
             elif len(auth) == 1:
-                return auth_error(400, 'error="invalid_request"')
+                return auth_error(4, 'error="invalid_request"')
             elif len(auth) > 2:
-                return auth_error(400, 'error="invalid_request"')
+                return auth_error(4, 'error="invalid_request"')
             token = auth[1]
             data = decrypt_token(token)
             if not data:
-                return auth_error(401, 'error="invalid_token"')
+                return auth_error(0, 'error="invalid_token"')
             user = User.query.filter_by(id=data['data']['user_id']).first()
             if required_authority and \
                     (user.authority not in required_authority):
-                return auth_error(403, 'error="insufficient_scope"')
+                return auth_error(15, 'error="insufficient_scope"')
             g.token_data = data['data']
 
             return f(*args, **kwargs)

--- a/api/auth.py
+++ b/api/auth.py
@@ -51,10 +51,10 @@ def login_required(*required_authority):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             def auth_error(code, headm=None):
-                resp = error_response(code)
+                resp, http_code = error_response(code)
                 if headm:
                     resp.headers['WWW-Authenticate'] = 'Bearer ' + headm
-                return resp
+                return resp, http_code
 
             time = get_current_datetime()
             end = current_app.config['END_DATETIME']

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,4 +1,4 @@
-from flask import make_response, g, current_app, jsonify, request
+from flask import g, current_app, request
 from cryptography.fernet import Fernet, InvalidToken
 from api.models import User
 from datetime import datetime

--- a/api/config.py
+++ b/api/config.py
@@ -13,6 +13,7 @@ class BaseConfig(object):
     SECRET_KEY = Fernet.generate_key()
     ROOT_DIR = Path(api.__file__).parent.parent
     ID_LIST_FILE = ROOT_DIR / Path('cards/ids.json')
+    ERROR_TABLE_FILE = ROOT_DIR / Path('errors.json')
     WINNERS_NUM = 90
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY')
     TIMEZONE = timezone(timedelta(hours=+9), 'JST')

--- a/api/error.py
+++ b/api/error.py
@@ -1,6 +1,6 @@
-from schemas import error_schema
-from models import Error
-
+from api.schemas import error_schema
+from api.models import Error
+from flask import jsonify
 
 def error_response(code):
     """

--- a/api/error.py
+++ b/api/error.py
@@ -10,6 +10,6 @@ def error_response(code):
         Returns:
             resp(Response): flask response with error message
     """
-    error = Error.query().filter_by(code=code).first()
+    error = Error.query.filter_by(code=code).first()
     result = error_schema.dump(error)[0]
     return jsonify(result), error.http_code

--- a/api/error.py
+++ b/api/error.py
@@ -1,6 +1,7 @@
 from schemas import error_schema
 from models import Error
 
+
 def error_response(code, http_code):
     """
         Construct json response from error code

--- a/api/error.py
+++ b/api/error.py
@@ -2,6 +2,7 @@ from api.schemas import error_schema
 from api.models import Error
 from flask import jsonify
 
+
 def error_response(code):
     """
         Construct json response from error code

--- a/api/error.py
+++ b/api/error.py
@@ -1,14 +1,15 @@
 from schemas import error_schema
 from models import Error
 
-def error_response(code):
+def error_response(code, http_code):
     """
         Construct json response from error code
         Args:
             code(int): Error Code specified in error table json file
+            http_code(int): HTTP Error Code
         Returns:
             resp(Response): flask response with error message
     """
     error = Error.query().filter_by(code=code).first()
     result = error_schema.dump(error)[0]
-    return jsonify(result)
+    return jsonify(result), http_code

--- a/api/error.py
+++ b/api/error.py
@@ -1,0 +1,14 @@
+from schemas import error_schema
+from models import Error
+
+def error_response(code):
+    """
+        Construct json response from error code
+        Args:
+            code(int): Error Code specified in error table json file
+        Returns:
+            resp(Response): flask response with error message
+    """
+    error = Error.query().filter_by(code=code).first()
+    result = error_schema.dump(error)[0]
+    return jsonify(result)

--- a/api/error.py
+++ b/api/error.py
@@ -2,15 +2,14 @@ from schemas import error_schema
 from models import Error
 
 
-def error_response(code, http_code):
+def error_response(code):
     """
         Construct json response from error code
         Args:
             code(int): Error Code specified in error table json file
-            http_code(int): HTTP Error Code
         Returns:
             resp(Response): flask response with error message
     """
     error = Error.query().filter_by(code=code).first()
     result = error_schema.dump(error)[0]
-    return jsonify(result), http_code
+    return jsonify(result), error.http_code

--- a/api/models.py
+++ b/api/models.py
@@ -141,6 +141,7 @@ class GroupMember(db.Model):
     def __repr__(self):
         return f"<GroupMember {self.user}>"
 
+
 class Error(db.Model):
     """
         Error model
@@ -157,6 +158,7 @@ class Error(db.Model):
 
     def __repr__(self):
         return f'<Error {self.code}: "{self.message}">'
+
 
 def group_member(application):
     return GroupMember(user_id=application.user_id,

--- a/api/models.py
+++ b/api/models.py
@@ -138,6 +138,7 @@ class GroupMember(db.Model):
     def __repr__(self):
         return f"<GroupMember {self.user}>"
 
+
 class Error(db.Model):
     """
         Error model

--- a/api/models.py
+++ b/api/models.py
@@ -137,3 +137,18 @@ class GroupMember(db.Model):
 
     def __repr__(self):
         return f"<GroupMember {self.user}>"
+
+class Error(db.Model):
+    """
+        Error model
+        DB contents:
+            code (int): identical error code, which has a common meaning
+                                    between frontend and backend
+            message (str): the description message
+    """
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.Integer, unique=True)
+    message = db.Column(db.String(200))
+
+    def __repr__(self):
+        return f'<Error {self.code}: "{self.message}">'

--- a/api/models.py
+++ b/api/models.py
@@ -145,10 +145,12 @@ class Error(db.Model):
         DB contents:
             code (int): identical error code, which has a common meaning
                                     between frontend and backend
+            http_code (int): the HTTP status code
             message (str): the description message
     """
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.Integer, unique=True)
+    http_code = db.Column(db.Integer)
     message = db.Column(db.String(200))
 
     def __repr__(self):

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -383,16 +383,16 @@ def check_id(classroom_id, secret_id):
     """
     user = User.query.filter_by(secret_id=secret_id).first()
     if not user:
-        return jsonify({"message": "user not found"}), 404
+        return error_response(5) # no such user found
     try:
         index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
-        return jsonify({"message": "Not acceptable time"}), 400
+        return error_response(6) # not acceptable time
     lottery = Lottery.query.filter_by(classroom_id=classroom_id,
                                       index=index).first()
     application = Application.query.filter_by(user=user,
                                               lottery=lottery).first()
     if not application:
-        return jsonify({"message": "application not found"}), 404
+        return error_response(19) # no application found
 
     return jsonify({"status": application.status})

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -24,6 +24,7 @@ from api.draw import (
     draw_one,
     draw_all_at_index,
 )
+from api.error import error_response
 
 bp = Blueprint(__name__, 'api')
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -136,7 +136,8 @@ def apply_lottery(idx):
             if any(app.lottery.index == lottery.index and
                    app.lottery.id != lottery.id
                    for app in previous.all()):
-                # Someone in the group is already applying to a lottery in this period
+                # Someone in the group is
+                # already applying to a lottery in this period
                 return error_response(8)
             if any(app.lottery.index == lottery.index and
                    app.lottery.id == lottery.id

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -368,7 +368,7 @@ def ids_hash():
     try:
         checksum = calc_sha256(current_app.config['ID_LIST_FILE'])
     except FileNotFoundError:
-        return jsonify({"message": "ID_LIST_FILE is not found"}), 404
+        return error_response(20) # ID_LIST_FILE not found
     return jsonify({"sha256": checksum})
 
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -368,7 +368,7 @@ def ids_hash():
     try:
         checksum = calc_sha256(current_app.config['ID_LIST_FILE'])
     except FileNotFoundError:
-        return error_response(20) # ID_LIST_FILE not found
+        return error_response(20)  # ID_LIST_FILE not found
     return jsonify({"sha256": checksum})
 
 
@@ -383,16 +383,16 @@ def check_id(classroom_id, secret_id):
     """
     user = User.query.filter_by(secret_id=secret_id).first()
     if not user:
-        return error_response(5) # no such user found
+        return error_response(5)  # no such user found
     try:
         index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
-        return error_response(6) # not acceptable time
+        return error_response(6)  # not acceptable time
     lottery = Lottery.query.filter_by(classroom_id=classroom_id,
                                       index=index).first()
     application = Application.query.filter_by(user=user,
                                               lottery=lottery).first()
     if not application:
-        return error_response(19) # no application found
+        return error_response(19)  # no application found
 
     return jsonify({"status": application.status})

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -116,7 +116,8 @@ def apply_lottery(idx):
     try:
         current_index = get_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
-        return error_response(14)  # We're not accepting any application in this hours.
+        # We're not accepting any application in this hours.
+        return error_response(14)
     if lottery.index != current_index:
         return error_response(11)  # This lottery is not acceptable now.
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -5,6 +5,7 @@ from ipaddress import ip_address
 from api.models import User
 from api.auth import generate_token
 from api.swagger import spec
+from api.error import error_response
 
 bp = Blueprint(__name__, 'auth')
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -22,10 +22,11 @@ def home():
     elif request.headers['Content-Type'] == 'application/json':
         data = request.json
     else:
-        return jsonify({"message": "Unsupported content type"}), 400
+        # Unsupported content type
+        return error_response(13)
 
     if 'id' not in data or 'g-recaptcha-response' not in data:
-        return jsonify({"message": "Invalid request"}), 400
+        return error_response(2)  # Invalid request
 
     # login flow
     secret_id = data.get('id')
@@ -46,4 +47,4 @@ def home():
             token = generate_token({'user_id': user.id})
             return jsonify({"message": "Login Successful",
                             "token": token.decode()})
-    return jsonify({"message": "Login Unsuccessful"}), 400
+    return error_response(3)  # Login unsuccessful

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -81,8 +81,10 @@ class LotterySchema(Schema):
 lottery_schema = LotterySchema()
 lotteries_schema = LotterySchema(many=True)
 
+
 class ErrorSchema(Schema):
     code = fields.Int()
     message = fields.Str()
+
 
 error_schema = ErrorSchema()

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -80,3 +80,9 @@ class LotterySchema(Schema):
 
 lottery_schema = LotterySchema()
 lotteries_schema = LotterySchema(many=True)
+
+class ErrorSchema(Schema):
+    code = fields.Int()
+    message = fields.Str()
+
+error_schema = ErrorSchema()

--- a/errors.json
+++ b/errors.json
@@ -78,5 +78,9 @@
   "19": {
     "message": "No application found",
     "status": 404
+  },
+  "20": {
+    "message": "ID_LIST_FILE not found",
+    "status": 404
   }
 }

--- a/errors.json
+++ b/errors.json
@@ -74,5 +74,9 @@
   "18": {
     "message": "We're not authorizing in this hours.",
     "status": 403
+  },
+  "19": {
+    "message": "No application found",
+    "status": 404
   }
 }

--- a/errors.json
+++ b/errors.json
@@ -1,20 +1,78 @@
 {
-  "00": "Authorization failed",
-  "01": "Invalid group member secret id",
-  "02": "Invalid request",
-  "03": "Login unsuccessful",
-  "04": "Malformed authenication header has detected",
-  "05": "No such user found",
-  "06": "Not acceptable time",
-  "07": "Not found",
-  "08": "Someone in the group is already applying to a lottery in this period",
-  "09": "Someone in the group is already applying to this lottery",
-  "10": "The Application has already fullfilled",
-  "11": "This lottery is not acceptable now.",
-  "12": "This lottery is not done yet.",
-  "13": "Unsupported content type",
-  "14": "We're not accepting any application in this hours.",
-  "15": "You have no permission to perform the action",
-  "16": "Your application is already accepted",
-  "17": "You’re already applying to a lottery in this period"
+  "00": {
+    "message": "Unauthorized",
+    "status": 401
+  },
+  "01": {
+    "message": "Invalid group member secret id",
+    "status": 401
+  },
+  "02": {
+    "message": "Invalid request",
+    "status": 400
+  },
+  "03": {
+    "message": "Login unsuccessful",
+    "status": 400
+  },
+  "04": {
+    "message": "Malformed authenication header has detected",
+    "status": 400
+  },
+  "05": {
+    "message": "No such user found",
+    "status": 404
+  },
+  "06": {
+    "message": "Not acceptable time",
+    "status": 400
+  },
+  "07": {
+    "message": "Not found",
+    "status": 404
+  },
+  "08": {
+    "message": "Someone in the group is already applying to a lottery in this period",
+    "status": 400
+  },
+  "09": {
+    "message": "Someone in the group is already applying to this lottery",
+    "status": 400
+  },
+  "10": {
+    "message": "The Application has already fullfilled",
+    "status": 400
+  },
+  "11": {
+    "message": "This lottery is not acceptable now.",
+    "status": 400
+  },
+  "12": {
+    "message": "This lottery is not done yet.",
+    "status": 400
+  },
+  "13": {
+    "message": "Unsupported content type",
+    "status": 400
+  },
+  "14": {
+    "message": "We're not accepting any application in this hours.",
+    "status": 400
+  },
+  "15": {
+    "message": "You have no permission to perform the action",
+    "status": 403
+  },
+  "16": {
+    "message": "Your application is already accepted",
+    "status": 400
+  },
+  "17": {
+    "message": "You’re already applying to a lottery in this period",
+    "status": 400
+  },
+  "18": {
+    "message": "We're not authorizing in this hours.",
+    "status": 403
+  }
 }

--- a/errors.json
+++ b/errors.json
@@ -1,0 +1,20 @@
+{
+  "00": "Authorization failed",
+  "01": "Invalid group member secret id",
+  "02": "Invalid request",
+  "03": "Login unsuccessful",
+  "04": "Malformed authenication header has detected",
+  "05": "No such user found",
+  "06": "Not acceptable time",
+  "07": "Not found",
+  "08": "Someone in the group is already applying to a lottery in this period",
+  "09": "Someone in the group is already applying to this lottery",
+  "10": "The Application has already fullfilled",
+  "11": "This lottery is not acceptable now.",
+  "12": "This lottery is not done yet.",
+  "13": "Unsupported content type",
+  "14": "We're not accepting any application in this hours.",
+  "15": "You have no permission to perform the action",
+  "16": "Your application is already accepted",
+  "17": "You’re already applying to a lottery in this period"
+}

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -50,7 +50,7 @@ def test_checker_no_application(client):
                            staff['g-recaptcha-response'],
                            f'/checker/{classroom_id}/{secret_id}')
     assert resp.status_code == 404
-    assert resp.get_json()['message'] == 'application not found'
+    assert resp.get_json()['message'] == 'No application found'
 
 
 def test_checker_invalid_user(client):
@@ -68,4 +68,4 @@ def test_checker_invalid_user(client):
                            f'/checker/{classroom_id}/{secret_id}')
 
     assert resp.status_code == 404
-    assert resp.get_json()['message'] == 'user not found'
+    assert resp.get_json()['message'] == 'No such user found'

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -1,4 +1,3 @@
-import pytest
 from api.error import error_response
 
 

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -1,0 +1,10 @@
+import pytest
+from api.error import error_response
+
+def test_error_response(client):
+    with client.application.app_context():
+        resp, http_code = error_response(0)
+        assert http_code is not None
+        assert 'message' in resp
+        assert 'code' in resp
+        assert resp['code'] == 0

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -4,6 +4,7 @@ from api.error import error_response
 def test_error_response(client):
     with client.application.app_context():
         resp, http_code = error_response(0)
+        resp = resp.get_json()
         assert http_code is not None
         assert 'message' in resp
         assert 'code' in resp

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -1,6 +1,7 @@
 import pytest
 from api.error import error_response
 
+
 def test_error_response(client):
     with client.application.app_context():
         resp, http_code = error_response(0)

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -69,7 +69,7 @@ def test_get_specific_classroom_invalid_id(client):
     resp = client.get(f'/classrooms/{idx}')
 
     assert resp.status_code == 404
-    assert 'Classroom could not be found.' in resp.get_json()['message']
+    assert 'Not found' in resp.get_json()['message']
 
 
 def test_get_alllotteries(client):
@@ -107,7 +107,7 @@ def test_get_specific_lottery_invalid_id(client):
     resp = client.get(f'/lotteries/{idx}')
 
     assert resp.status_code == 404
-    assert 'Lottery could not be found.' in resp.get_json()['message']
+    assert 'Not found' in resp.get_json()['message']
 
 
 def test_apply_normal(client):
@@ -184,7 +184,7 @@ def test_apply_invalid(client):
                        json={'group_members': []})
 
     assert resp.status_code == 404
-    assert 'Lottery could not be found.' in resp.get_json()['message']
+    assert 'Not found' in resp.get_json()['message']
 
 
 def test_apply_same_period(client):
@@ -403,7 +403,7 @@ def test_apply_group_same_lottery(client):
                            json={'group_members': members})
 
         assert resp.status_code == 400
-        assert 'someone in the group is already applying to this lottery' in \
+        assert 'Someone in the group is already applying to this lottery' in \
             resp.get_json()['message']
 
 
@@ -493,7 +493,7 @@ def test_get_specific_application_invaild_id(client):
                        f'/applications/{idx}')
 
     assert resp.status_code == 404
-    assert 'Application could not be found.' in resp.get_json()['message']
+    assert 'Not found' in resp.get_json()['message']
 
 
 def test_cancel_normal(client):
@@ -809,7 +809,7 @@ def test_draw_noperm(client):
                        headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 403
-    assert 'Forbidden' in resp.get_json()['message']
+    assert 'You have no permission to perform the action' in resp.get_json()['message']
 
 
 def test_draw_invalid(client):
@@ -824,7 +824,7 @@ def test_draw_invalid(client):
                        headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 404
-    assert 'Lottery could not be found.' in resp.get_json()['message']
+    assert 'Not found' in resp.get_json()['message']
 
 
 def test_draw_time_invalid(client):
@@ -955,7 +955,7 @@ def test_draw_all_noperm(client):
                        headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 403
-    assert 'Forbidden' in resp.get_json()['message']
+    assert 'You have no permission to perform the action' in resp.get_json()['message']
 
 
 def test_draw_all_invalid(client):

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -809,7 +809,8 @@ def test_draw_noperm(client):
                        headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 403
-    assert 'You have no permission to perform the action' in resp.get_json()['message']
+    assert 'You have no permission to perform the action' in \
+        resp.get_json()['message']
 
 
 def test_draw_invalid(client):
@@ -955,7 +956,8 @@ def test_draw_all_noperm(client):
                        headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 403
-    assert 'You have no permission to perform the action' in resp.get_json()['message']
+    assert 'You have no permission to perform the action' in \
+        resp.get_json()['message']
 
 
 def test_draw_all_invalid(client):

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -182,7 +182,7 @@ def test_auth_used_user(client):
                            }, follow_redirects=True)
 
     assert resp.status_code == 400
-    assert resp.get_json()['message'] == 'Login Unsuccessful'
+    assert resp.get_json()['message'] == 'Login unsuccessful'
 
 
 def test_auth_overtime_as_student(client):

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -25,7 +25,7 @@ def test_login(client):
                  test_user['g-recaptcha-response'])
     assert 'Login Successful' in resp['message']
     resp = login(client, 'notexist', 'notexist')
-    assert 'Login Unsuccessful' in resp['message']
+    assert 'Login unsuccessful' in resp['message']
 
 
 def test_login_form(client):
@@ -43,7 +43,7 @@ def test_login_form(client):
         client, test_user['secret_id'], test_user['g-recaptcha-response'])
     assert 'Login Successful' in resp['message']
     resp = login_with_form(client, 'notexist', 'notexist')
-    assert 'Login Unsuccessful' in resp['message']
+    assert 'Login unsuccessful' in resp['message']
 
 
 def test_login_invalid(client):
@@ -153,4 +153,4 @@ def test_translate_user_ids_invalid_secret_id(client):
                       headers={'Authorization': f'Bearer {token}'})
 
     assert resp.status_code == 404
-    assert 'no such user found' in resp.get_json()['message']
+    assert 'No such user found' in resp.get_json()['message']


### PR DESCRIPTION
 * OS: Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@62a3d67ea6b79852a6afb5b936cdece0ccd391b2
 * Sakuten/frontend@270ddc810fc6b367c7456657127ed6943df0b484
 * Sakuten/backend@e8f59d17797ccd78e6902283e54d262de5e42a81

変更内容
================

  * エラーコードとエラーメッセージ、httpステータスコードの対応テーブルをつくった(`errors.json`)
  * 今までメッセージを指定していた部分をエラー番号を指定し、そこからエラーを返すようにした
  * `Error`モデルを作り起動時にjsonからロード

修正前の挙動:
-------------

  * `return jsonify({"message": "I'm a teapot"}), 418`

修正後の挙動:
-------------

  * `return error_response(0)`

影響範囲
================

  * テストコードを書き換えた
  * これ、enum化したほうがいいすかね。`return error_respose(errors.NotFound)`みたいな
  * いつも思うんだけどこれDBにストアする必要あんまないよな...
  * テスト足りてる?
  * 絶対API Schemaと乖離する。絶対に、だ
