### PR TITLE
scripts/draw.pyで`ids.json`のハッシュ確認をした

### DIFF
--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -11,6 +11,7 @@ import sys
 import argparse
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
+import hashlib
 
 parser = argparse.ArgumentParser(
     description='Draw currently available lotteries')
@@ -48,6 +49,14 @@ def post_json(path, data=None, token=None):
         response_body = response.read().decode("utf-8")
         response.close()
         return json.loads(response_body)
+
+
+with open(args.list, 'r') as f:
+    local_checksum = hashlib.sha256(f.read().encode()).hexdigest()
+    server_checksum = post_json('ids_hash')['sha256']
+    if local_checksum != server_checksum:
+        print('local ids.json is different from servers', file=sys.stderr)
+        sys.exit(70)  # we should decide error code
 
 
 # Login as admin


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

 * OS: Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * devenv: 3c7149cce36dbdaa611a642d4aedd97ea86028c1
 * frontend: f48a2af56869c6b1d8e279f66402865f49e9c1d6
 * backend: 5b32cd18fd6db44c352522116cc71b579a799b61

変更内容
================

  * 抽選を行う際、トークン生成に使う`ids.json`が、鯖側とローカルで一致しているかを確認するようになりました。
  * 違っていた場合、`$?=70`で終了します。(`/usr/include/sysexits.h`)
  * 又、その場合`local ids.json is different from servers`が標準エラー出力に出力されます。
  * #150

修正前の挙動:
-------------

  * たとえ`ids.json`が異なっていても、特段判別することができなかった。

修正後の挙動:
-------------

  * `ids.json`が異なっていた場合、エラーを吐いて終了するようになった。

影響範囲
================

  * `scripts/draw.py`のテストもないので、なし。