### PR TITLE
Provide options to control DB initialization ways

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && apk upgrade \
     && apk del --purge .build-deps \
     && rm -rf /var/cache/apk/*
 
+ENV DB_GEN_POLICY never
 EXPOSE 80
 
 CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:80"]

--- a/api/app.py
+++ b/api/app.py
@@ -71,13 +71,16 @@ def create_app():
     app.register_blueprint(api.bp)
 
     policy = os.getenv('DB_GEN_POLICY', 'first_time')
-    if policy != 'never':
-        with app.app_context():
-            is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
+    with app.app_context():
+        is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
+        if is_empty:
+            app.logger.warning(
+                f'Creating all tables')
+            db.create_all()
+        if policy != 'never':
             if policy == 'always' or (policy == 'first_time' and is_empty):
                 app.logger.warning(
                         f'Generating Initial Data for Database (DB_GEN_POLICY: {policy})')
-                db.create_all()
                 generate()
 
     return app

--- a/api/app.py
+++ b/api/app.py
@@ -75,13 +75,14 @@ def create_app():
 
     return app
 
+
 def init_and_generate():
     policy = current_app.config['DB_GEN_POLICY']
     force_init = current_app.config['DB_FORCE_INIT']
     is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
     if force_init and not is_empty:
         current_app.logger.warning('Dropping all tables because '
-                           f'DB_FORCE_INIT == true')
+                                   f'DB_FORCE_INIT == true')
         db.drop_all()
     if force_init or is_empty:
         current_app.logger.warning(f'Creating all tables')
@@ -95,6 +96,7 @@ def init_and_generate():
     elif policy != 'never' and policy != 'first_time':
         current_app.logger.warning(
             f'Unknown DB_GEN_POLICY: {policy}. Treated as \'never\'.')
+
 
 def initdb(app, db):
     from api.models import db

--- a/api/app.py
+++ b/api/app.py
@@ -77,11 +77,14 @@ def create_app():
             app.logger.warning(
                 f'Creating all tables')
             db.create_all()
-        if policy != 'never':
-            if policy == 'always' or (policy == 'first_time' and is_empty):
-                app.logger.warning(
-                        f'Generating Initial Data for Database (DB_GEN_POLICY: {policy})')
-                generate()
+        if policy == 'always' or (policy == 'first_time' and User.query.all() == []):
+            app.logger.warning(
+                    f'Generating Initial Data for Database (DB_GEN_POLICY: {policy})')
+            generate()
+        elif policy != 'never':
+            app.logger.warning(
+                    f'Unknown DB_GEN_POLICY: {policy}. Treated as \'never\'.')
+
 
     return app
 

--- a/api/app.py
+++ b/api/app.py
@@ -79,7 +79,7 @@ def create_app():
 def init_and_generate():
     policy = current_app.config['DB_GEN_POLICY']
     force_init = current_app.config['DB_FORCE_INIT']
-    is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
+    is_empty = len(sqlalchemy.inspect(db.engine).get_table_names()) == 0
     if force_init and not is_empty:
         current_app.logger.warning('Dropping all tables because '
                                    f'DB_FORCE_INIT == true')
@@ -88,7 +88,7 @@ def init_and_generate():
         current_app.logger.warning(f'Creating all tables')
         db.create_all()
     if policy == 'always' or \
-            (policy == 'first_time' and User.query.all() == []):
+            (policy == 'first_time' and len(User.query.all()) == 0):
         current_app.logger.warning(
             'Generating Initial Data for Database '
             f'(DB_GEN_POLICY: {policy})')

--- a/api/app.py
+++ b/api/app.py
@@ -87,7 +87,7 @@ def create_app():
                 'Generating Initial Data for Database '
                 f'(DB_GEN_POLICY: {policy})')
             generate()
-        elif policy != 'never':
+        elif policy != 'never' and policy != 'first_time':
             app.logger.warning(
                 f'Unknown DB_GEN_POLICY: {policy}. Treated as \'never\'.')
 

--- a/api/app.py
+++ b/api/app.py
@@ -3,7 +3,7 @@ from flask_cors import CORS
 import sqlalchemy
 from .routes import auth, api
 from .swagger import swag
-from .models import db
+from .models import db, User
 from cards.id import load_id_json_file, decode_public_id
 import os
 import sys

--- a/api/app.py
+++ b/api/app.py
@@ -75,21 +75,21 @@ def create_app():
     with app.app_context():
         is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
         if force_init and not is_empty:
-            app.logger.warning(
-                f'Dropping all tables because DB_FORCE_INIT == true')
+            app.logger.warning('Dropping all tables because '
+                               f'DB_FORCE_INIT == true')
             db.drop_all()
         if force_init or is_empty:
-            app.logger.warning(
-                f'Creating all tables')
+            app.logger.warning(f'Creating all tables')
             db.create_all()
-        if policy == 'always' or (policy == 'first_time' and User.query.all() == []):
+        if policy == 'always' or \
+                (policy == 'first_time' and User.query.all() == []):
             app.logger.warning(
-                    f'Generating Initial Data for Database (DB_GEN_POLICY: {policy})')
+                'Generating Initial Data for Database '
+                f'(DB_GEN_POLICY: {policy})')
             generate()
         elif policy != 'never':
             app.logger.warning(
-                    f'Unknown DB_GEN_POLICY: {policy}. Treated as \'never\'.')
-
+                f'Unknown DB_GEN_POLICY: {policy}. Treated as \'never\'.')
 
     return app
 

--- a/api/app.py
+++ b/api/app.py
@@ -133,11 +133,15 @@ def generate():
                               index=perf_index, done=False)
             db.session.add(lottery)
 
+    Classroom.query.delete()
     classloop(create_classrooms)
     db.session.commit()
+
+    Lottery.query.delete()
     classloop(create_lotteries)
     db.session.commit()
 
+    User.query.delete()
     json_path = current_app.config['ID_LIST_FILE']
     id_list = load_id_json_file(json_path)
     for ids in id_list:
@@ -149,6 +153,7 @@ def generate():
 
     db.session.commit()
 
+    Error.query.delete()
     json_path = current_app.config['ERROR_TABLE_FILE']
     with open(json_path, 'r') as f:
         error_list = json.load(f)

--- a/api/app.py
+++ b/api/app.py
@@ -70,12 +70,15 @@ def create_app():
     app.register_blueprint(auth.bp)
     app.register_blueprint(api.bp)
 
-    with app.app_context():
-        if sqlalchemy.inspect(db.engine).get_table_names() == []:
-            app.logger.warning(
-                'Generating Initial Data for Database in the first run')
-            db.create_all()
-            generate()
+    db_gen = os.getenv('DB_GEN', 'first_time')
+    if db_gen != 'never':
+        with app.app_context():
+            is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
+            if db_gen == 'always' or (db_gen == 'first_time' and is_empty):
+                app.logger.warning(
+                        f'Generating Initial Data for Database (DB_GEN: {db_gen})')
+                db.create_all()
+                generate()
 
     return app
 

--- a/api/app.py
+++ b/api/app.py
@@ -101,10 +101,10 @@ def init_and_generate():
     is_empty = len(sqlalchemy.inspect(db.engine).get_table_names()) == 0
     if force_init and not is_empty:
         current_app.logger.warning('Dropping all tables because '
-                                   f'DB_FORCE_INIT == true')
+                                   'DB_FORCE_INIT == true')
         db.drop_all()
     if force_init or is_empty:
-        current_app.logger.warning(f'Creating all tables')
+        current_app.logger.warning('Creating all tables')
         db.create_all()
     if policy == 'always' or \
             (policy == 'first_time' and len(User.query.all()) == 0):

--- a/api/app.py
+++ b/api/app.py
@@ -71,9 +71,14 @@ def create_app():
     app.register_blueprint(api.bp)
 
     policy = os.getenv('DB_GEN_POLICY', 'first_time')
+    force_init = os.getenv('DB_FORCE_INIT', 'false') == 'true'
     with app.app_context():
         is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
-        if is_empty:
+        if force_init and not is_empty:
+            app.logger.warning(
+                f'Dropping all tables because DB_FORCE_INIT == true')
+            db.drop_all()
+        if force_init or is_empty:
             app.logger.warning(
                 f'Creating all tables')
             db.create_all()

--- a/api/app.py
+++ b/api/app.py
@@ -70,13 +70,13 @@ def create_app():
     app.register_blueprint(auth.bp)
     app.register_blueprint(api.bp)
 
-    db_gen = os.getenv('DB_GEN', 'first_time')
-    if db_gen != 'never':
+    policy = os.getenv('DB_GEN_POLICY', 'first_time')
+    if policy != 'never':
         with app.app_context():
             is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
-            if db_gen == 'always' or (db_gen == 'first_time' and is_empty):
+            if policy == 'always' or (policy == 'first_time' and is_empty):
                 app.logger.warning(
-                        f'Generating Initial Data for Database (DB_GEN: {db_gen})')
+                        f'Generating Initial Data for Database (DB_GEN_POLICY: {policy})')
                 db.create_all()
                 generate()
 

--- a/api/app.py
+++ b/api/app.py
@@ -77,6 +77,25 @@ def create_app():
 
 
 def init_and_generate():
+    """
+        Intialize and generate DB if needed,
+        depends on DB_GEN_POLICY and DB_FORCE_INIT.
+
+        application context is required.
+
+        * DB_GEN_POLICY=[always|first_time|never]
+          * always: Generates initial data every time.
+                    (existing User, Classroom, Lottery, Error is deleted)
+          * first_time: When initial data is not generated yes, generates.
+          * never: Never generates initial data (for deployments)
+
+        * DB_FORCE_INIT=[true|false]
+          * true: Deletes all tables and re-creates
+          * false: If there is no tables, creates them
+
+        Args:
+        Return:
+    """
     policy = current_app.config['DB_GEN_POLICY']
     force_init = current_app.config['DB_FORCE_INIT']
     is_empty = len(sqlalchemy.inspect(db.engine).get_table_names()) == 0

--- a/api/app.py
+++ b/api/app.py
@@ -70,8 +70,8 @@ def create_app():
     app.register_blueprint(auth.bp)
     app.register_blueprint(api.bp)
 
-    policy = os.getenv('DB_GEN_POLICY', 'first_time')
-    force_init = os.getenv('DB_FORCE_INIT', 'false') == 'true'
+    policy = app.config['DB_GEN_POLICY']
+    force_init = app.config['DB_FORCE_INIT']
     with app.app_context():
         is_empty = sqlalchemy.inspect(db.engine).get_table_names() == []
         if force_init and not is_empty:

--- a/api/config.py
+++ b/api/config.py
@@ -10,6 +10,8 @@ class BaseConfig(object):
     TESTING = False
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@db/postgres'
+    DB_GEN_POLICY = os.getenv('DB_GEN_POLICY', 'first_time')
+    DB_FORCE_INIT = os.getenv('DB_FORCE_INIT', 'false') == 'true'
     SECRET_KEY = Fernet.generate_key()
     ROOT_DIR = Path(api.__file__).parent.parent
     ID_LIST_FILE = ROOT_DIR / Path('cards/ids.json')

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -1,9 +1,8 @@
-import pytest
-
 from sqlalchemy import event
 
 from api.models import db, Classroom, Lottery, User, Error
-from api.app import create_app, init_and_generate
+from api.app import init_and_generate
+
 
 def test_db_generate_never(client):
     with client.application.app_context():

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -2,7 +2,7 @@ import pytest
 
 from sqlalchemy import event
 
-from api.models import db, Classroom, Lottery, User
+from api.models import db, Classroom, Lottery, User, Error
 from api.app import create_app, init_and_generate
 
 def test_db_generate_never(client):
@@ -14,6 +14,7 @@ def test_db_generate_never(client):
         assert len(User.query.all()) == 0
         assert len(Classroom.query.all()) == 0
         assert len(Lottery.query.all()) == 0
+        assert len(Error.query.all()) == 0
 
 def test_db_generate_first_time(client):
     with client.application.app_context():
@@ -37,6 +38,7 @@ def test_db_generate_first_time(client):
         assert len(User.query.all()) != 0
         assert len(Classroom.query.all()) != 0
         assert len(Lottery.query.all()) != 0
+        assert len(Error.query.all()) != 0
 
         changed = False
         init_and_generate()  # initial data is already generated, so does nothing
@@ -64,3 +66,4 @@ def test_db_generate_always(client):
         assert len(User.query.all()) != 0
         assert len(Classroom.query.all()) != 0
         assert len(Lottery.query.all()) != 0
+        assert len(Error.query.all()) != 0

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -5,6 +5,11 @@ from api.app import init_and_generate
 
 
 def test_db_generate_never(client):
+    """
+        Test if `DB_GEN_POLICY == 'never'` is working.
+        See the definition of `init_and_generate`
+        for expected behavior.
+    """
     with client.application.app_context():
         client.application.config['DB_FORCE_INIT'] = True
         client.application.config['DB_GEN_POLICY'] = 'never'
@@ -17,6 +22,11 @@ def test_db_generate_never(client):
 
 
 def test_db_generate_first_time(client):
+    """
+        Test if `DB_GEN_POLICY == 'first_time'` is working.
+        See the definition of `init_and_generate`
+        for expected behavior.
+    """
     with client.application.app_context():
         client.application.config['DB_FORCE_INIT'] = True
         client.application.config['DB_GEN_POLICY'] = 'never'
@@ -51,6 +61,11 @@ def test_db_generate_first_time(client):
 
 
 def test_db_generate_always(client):
+    """
+        Test if `DB_GEN_POLICY == 'always'` is working.
+        See the definition of `init_and_generate`
+        for expected behavior.
+    """
     with client.application.app_context():
         client.application.config['DB_GEN_POLICY'] = 'always'
 

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -1,0 +1,46 @@
+import pytest
+
+from sqlalchemy import event
+
+from api.models import db, Classroom, Lottery, User
+from api.app import create_app, init_and_generate
+
+def test_db_generate_never(client):
+    with client.application.app_context():
+        client.application.config['DB_FORCE_INIT'] = True
+        client.application.config['DB_GEN_POLICY'] = 'never'
+        init_and_generate()  # tables created, but initial data not generated
+
+        assert len(User.query.all()) == 0
+        assert len(Classroom.query.all()) == 0
+        assert len(Lottery.query.all()) == 0
+
+def test_db_generate_first_time(client):
+    with client.application.app_context():
+        client.application.config['DB_FORCE_INIT'] = True
+        client.application.config['DB_GEN_POLICY'] = 'never'
+        init_and_generate()  # tables created, but initial data not generated
+
+        client.application.config['DB_FORCE_INIT'] = False
+        client.application.config['DB_GEN_POLICY'] = 'first_time'
+
+        changed = False
+
+        @event.listens_for(db.session, 'before_commit')
+        def detect_change(*args,**kw):
+            nonlocal changed
+            changed = True
+
+        init_and_generate()  # initial data generated
+
+        assert changed
+        assert len(User.query.all()) != 0
+        assert len(Classroom.query.all()) != 0
+        assert len(Lottery.query.all()) != 0
+
+        changed = False
+        init_and_generate()  # initial data generated, so does nothing
+        event.remove(db.session, 'before_commit', detect_change)
+
+        assert not changed
+

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -16,6 +16,7 @@ def test_db_generate_never(client):
         assert len(Lottery.query.all()) == 0
         assert len(Error.query.all()) == 0
 
+
 def test_db_generate_first_time(client):
     with client.application.app_context():
         client.application.config['DB_FORCE_INIT'] = True
@@ -28,7 +29,7 @@ def test_db_generate_first_time(client):
         changed = False
 
         @event.listens_for(db.session, 'before_commit')
-        def detect_change(*args,**kw):
+        def detect_change(*args, **kw):
             nonlocal changed
             changed = True
 
@@ -46,6 +47,7 @@ def test_db_generate_first_time(client):
 
         assert not changed
 
+
 def test_db_generate_always(client):
     with client.application.app_context():
         client.application.config['DB_GEN_POLICY'] = 'always'
@@ -53,7 +55,7 @@ def test_db_generate_always(client):
         changed = False
 
         @event.listens_for(db.session, 'before_commit')
-        def detect_change(*args,**kw):
+        def detect_change(*args, **kw):
             nonlocal changed
             changed = True
 

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -61,3 +61,6 @@ def test_db_generate_always(client):
         event.remove(db.session, 'before_commit', detect_change)
 
         assert changed
+        assert len(User.query.all()) != 0
+        assert len(Classroom.query.all()) != 0
+        assert len(Lottery.query.all()) != 0

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -39,8 +39,25 @@ def test_db_generate_first_time(client):
         assert len(Lottery.query.all()) != 0
 
         changed = False
-        init_and_generate()  # initial data generated, so does nothing
+        init_and_generate()  # initial data is already generated, so does nothing
         event.remove(db.session, 'before_commit', detect_change)
 
         assert not changed
 
+def test_db_generate_always(client):
+    with client.application.app_context():
+        client.application.config['DB_GEN_POLICY'] = 'always'
+
+        changed = False
+
+        @event.listens_for(db.session, 'before_commit')
+        def detect_change(*args,**kw):
+            nonlocal changed
+            changed = True
+
+        # initial data is already generated,
+        # However re-generates the data
+        init_and_generate()
+        event.remove(db.session, 'before_commit', detect_change)
+
+        assert changed

--- a/test/test_db_generate.py
+++ b/test/test_db_generate.py
@@ -41,7 +41,10 @@ def test_db_generate_first_time(client):
         assert len(Error.query.all()) != 0
 
         changed = False
-        init_and_generate()  # initial data is already generated, so does nothing
+
+        # initial data is already generated,
+        # so does nothing
+        init_and_generate()
         event.remove(db.session, 'before_commit', detect_change)
 
         assert not changed

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -10,7 +10,6 @@ def test_db_init(client, force_init):
         db.session.add(dummy)
         db.session.commit()
         dummy_id = dummy.id
-        assert Classroom.query.get(dummy_id) is not None
 
         client.application.config['DB_FORCE_INIT'] = force_init
         init_and_generate()

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -3,6 +3,7 @@ import pytest
 from api.models import db, Classroom
 from api.app import create_app, init_and_generate
 
+
 @pytest.mark.parametrize("force_init", [True, False])
 def test_db_init(client, force_init):
     with client.application.app_context():

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -1,7 +1,10 @@
+import pytest
+
 from api.models import db, Classroom
 from api.app import create_app, init_and_generate
 
-def test_db_not_force_init(client):
+@pytest.mark.parametrize("force_init", [True, False])
+def test_db_init(client, force_init):
     with client.application.app_context():
         dummy = Classroom(grade=0, index=0)
         db.session.add(dummy)
@@ -9,18 +12,9 @@ def test_db_not_force_init(client):
         dummy_id = dummy.id
         assert Classroom.query.get(dummy_id) is not None
 
-        client.application.config['DB_FORCE_INIT'] = False
+        client.application.config['DB_FORCE_INIT'] = force_init
         init_and_generate()
-        assert Classroom.query.get(dummy_id) is not None
-
-def test_db_force_init(client):
-    with client.application.app_context():
-        dummy = Classroom(grade=0, index=0)
-        db.session.add(dummy)
-        db.session.commit()
-        dummy_id = dummy.id
-        assert Classroom.query.get(dummy_id) is not None
-
-        client.application.config['DB_FORCE_INIT'] = True
-        init_and_generate()
-        assert Classroom.query.get(dummy_id) is None
+        if force_init:
+            assert Classroom.query.get(dummy_id) is None
+        else:
+            assert Classroom.query.get(dummy_id) is not None

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.models import db, Classroom
-from api.app import create_app, init_and_generate
+from api.app import init_and_generate
 
 
 @pytest.mark.parametrize("force_init", [True, False])

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -1,0 +1,14 @@
+from api.models import db, Classroom
+from api.app import create_app, init_and_generate
+
+def test_db_force_init(client):
+    with client.application.app_context():
+        dummy = Classroom(grade=0, index=0)
+        db.session.add(dummy)
+        db.session.commit()
+        dummy_id = dummy.id
+        assert Classroom.query.get(dummy_id) is not None
+
+        client.application.config['DB_FORCE_INIT'] = True
+        init_and_generate()
+        assert Classroom.query.get(dummy_id) is None

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -1,6 +1,18 @@
 from api.models import db, Classroom
 from api.app import create_app, init_and_generate
 
+def test_db_not_force_init(client):
+    with client.application.app_context():
+        dummy = Classroom(grade=0, index=0)
+        db.session.add(dummy)
+        db.session.commit()
+        dummy_id = dummy.id
+        assert Classroom.query.get(dummy_id) is not None
+
+        client.application.config['DB_FORCE_INIT'] = False
+        init_and_generate()
+        assert Classroom.query.get(dummy_id) is not None
+
 def test_db_force_init(client):
     with client.application.app_context():
         dummy = Classroom(grade=0, index=0)

--- a/test/test_db_init.py
+++ b/test/test_db_init.py
@@ -6,6 +6,11 @@ from api.app import init_and_generate
 
 @pytest.mark.parametrize("force_init", [True, False])
 def test_db_init(client, force_init):
+    """
+        Test if `DB_FORCE_INIT` is working.
+        See the definition of `init_and_generate`
+        for expected behavior.
+    """
     with client.application.app_context():
         dummy = Classroom(grade=0, index=0)
         db.session.add(dummy)


### PR DESCRIPTION
* Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@ebb6c80fda909a148ec85fa92cbe81854391b614
 * Sakuten/backend@de15d3a5625ebb6da86eb5c4e9ee923e85b7d86b

変更内容
================

  * Fix #162 
  * `DB_GEN_POLICY=[always|first_time|never]`
    * always: 常に初期データを生成する（User, Classroom, Lottery, Errorの内容を削除し再生成)
    * first_time: 初期データがなかったら(`User.query.all() == []`)生成する(デフォルト)
    * never: 初期データを生成しない(デプロイ用)
  * `DB_FORCE_INIT=[true|false]`
    * true: 強制的に全テーブルを削除、生成
    * false: もしテーブルがなかったら、テーブルを生成(デフォルト）

修正前の挙動:
-------------

  * DBを初期化しようと思うといろいろ面倒
  * 初期データが常に生成されてしまいデプロイで競合する

修正後の挙動:
-------------

  * 解決

影響範囲
================

  * ない
