### PR TITLE
Run initialization only once

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -70,8 +70,7 @@ def create_app():
     app.register_blueprint(auth.bp)
     app.register_blueprint(api.bp)
 
-    with app.app_context():
-        init_and_generate()
+    app.before_first_request(init_and_generate)
 
     return app
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,9 @@ def client():
         test_cred = next(test_creds)
         user['secret_id'] = test_cred['secret_id']
 
+    with client.app_context():
+        app.init_and_generate()
+
     test_client = client.test_client()
 
     yield test_client


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@ebb6c80fda909a148ec85fa92cbe81854391b614
 * Sakuten/backend@b03abca83dc64bf3488c9845cb86fb3a68b31586

変更内容
================

  * Fix #139 
  * 最初のアクセスの時に初期化を走らせるため、複数workerで初期化が競合したりしない。

修正前の挙動:
-------------

  * #139

修正後の挙動:
-------------

  * ✨

影響範囲
================

  * テストの時は明示的に`fixture`で初期化を走らせています。
