### PR TITLE
`/ids_hash`のHTTPステータスコード変更

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -81,6 +81,6 @@
   },
   "20": {
     "message": "ID_LIST_FILE not found",
-    "status": 404
+    "status": 500
   }
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * `/ids_hash`にて、`ID_LIST_FILE`が見つからなかった場合のエラーについて、`HTTP status code`を修正しました。
  * `404`  → `500`になりました。これは、ユーザー側ではなくサーバー側の問題であるからです。
  * #167

修正前の挙動:
-------------

  * `/ids_hash`において、`ID_LIST_FILE`が存在していなかった場合`404`を返す

修正後の挙動:
-------------

  * `/ids_hash`において、`ID_LIST_FILE`が存在していなかった場合`500`を返す

影響範囲
================

  * 今回の変更部分**以外**に、この変更が影響を与えそうなところがあったら書いてください