### PR TITLE
Fix to return empty list when got OutOfHoursError or OutOfAcceptingHoursError in /lotteries/available

### DIFF
--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -85,7 +85,7 @@ def list_available_lotteries():
 
     try:
         index = get_time_index()
-    except OutOfAcceptingHoursError:
+    except (OutOfAcceptingHoursError, OutOfHoursError):
         return jsonify({"message": "Not acceptable time"}), 400
     lotteries = Lottery.query.filter_by(index=index)
 

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -86,7 +86,7 @@ def list_available_lotteries():
     try:
         index = get_time_index()
     except (OutOfAcceptingHoursError, OutOfHoursError):
-        return jsonify({"message": "Not acceptable time"}), 400
+        return jsonify([])
     lotteries = Lottery.query.filter_by(index=index)
 
     result = lotteries_schema.dump(lotteries)[0]

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -27,7 +27,11 @@ from api.schemas import (
     lotteries_schema,
     lottery_schema
 )
-from api.time_management import mod_time, OutOfHoursError, OutOfAcceptingHoursError
+from api.time_management import (
+    mod_time,
+    OutOfHoursError,
+    OutOfAcceptingHoursError
+)
 from itertools import chain
 
 

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -27,7 +27,7 @@ from api.schemas import (
     lotteries_schema,
     lottery_schema
 )
-from api.time_management import mod_time
+from api.time_management import mod_time, OutOfHoursError, OutOfAcceptingHoursError
 from itertools import chain
 
 
@@ -100,6 +100,23 @@ def test_get_all_available_lotteries(client):
 
     assert current_lotteries == resp.get_json()
 
+def test_get_all_available_lotteries_out_of_time(client):
+    """test proper infomation is returned from the API
+        when it is out of time
+        target_url: /lotteries/available
+    """
+    index = 1
+    with mock.patch('api.routes.api.get_time_index',
+                    side_effect=OutOfHoursError()):
+        resp = client.get('/lotteries/available')
+
+    assert [] == resp.get_json()
+
+    with mock.patch('api.routes.api.get_time_index',
+                    side_effect=OutOfAcceptingHoursError()):
+        resp = client.get('/lotteries/available')
+
+    assert [] == resp.get_json()
 
 def test_get_specific_lottery(client):
     """test proper infomation is returned from the API

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -104,12 +104,12 @@ def test_get_all_available_lotteries(client):
 
     assert current_lotteries == resp.get_json()
 
+
 def test_get_all_available_lotteries_out_of_time(client):
     """test proper infomation is returned from the API
         when it is out of time
         target_url: /lotteries/available
     """
-    index = 1
     with mock.patch('api.routes.api.get_time_index',
                     side_effect=OutOfHoursError()):
         resp = client.get('/lotteries/available')
@@ -121,6 +121,7 @@ def test_get_all_available_lotteries_out_of_time(client):
         resp = client.get('/lotteries/available')
 
     assert [] == resp.get_json()
+
 
 def test_get_specific_lottery(client):
     """test proper infomation is returned from the API


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@ebb6c80fda909a148ec85fa92cbe81854391b614
 * Sakuten/backend@93f12ab2d74c31967249d4aa424d86c9e1c579f0

変更内容
================

  * 時間外に/lotteries/availableにアクセスした時に、
  * エラーを返すのではなく[]を返す
  * Fix #180

修正前の挙動:
-------------

  * エラー
  * OutOfHoursErrorに至っては500番台

修正後の挙動:
-------------

  * []

影響範囲
================

  * ない
