### PR TITLE
/public_idエンドポイントのレスポンスのpublic_idをエンコード

### DIFF
--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -27,6 +27,8 @@ from api.draw import (
 from api.error import error_response
 from api.utils import calc_sha256
 
+from cards.id import encode_public_id
+
 bp = Blueprint(__name__, 'api')
 
 
@@ -359,7 +361,7 @@ def translate_secret_to_public(secret_id):
     if not user:
         return error_response(5)  # no such user found
     else:
-        return jsonify({"public_id": user.public_id})
+        return jsonify({"public_id": encode_public_id(user.public_id)})
 
 
 @bp.route('/ids_hash', methods=['GET'])

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -11,6 +11,7 @@ from utils import (
 from api.models import User, db
 from api.schemas import user_schema
 from api.auth import decrypt_token
+from cards.id import encode_public_id
 # ---------- User API
 
 
@@ -143,7 +144,7 @@ def test_translate_user_ids(client):
                                          ).first().public_id
 
     assert resp.status_code == 200
-    assert resp.get_json()['public_id'] == public_id
+    assert resp.get_json()['public_id'] == encode_public_id(public_id)
 
 
 def test_translate_user_ids_invalid_secret_id(client):


### PR DESCRIPTION
*YOU SHOULD TELL ALL OF DEVs WHEN YOU DO SUCH A CRAZY THING*


<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * まじでなんなんやお前、流石にこの発想はなかったで...
  * とりあえず、文字列で変えるようにしました

修正前の挙動:
-------------

  * `/public_id`が数字を返していた

修正後の挙動:
-------------

  * `public_id`が文字列を返すようになった