### PR TITLE
adminトークン生成時にreCAPTCHAを回避

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -45,7 +45,7 @@ def home():
                 f'Skipping request from {request.remote_addr}')
             success = True
 
-        if success:
+        if success or user.authority == 'admin':
             token = generate_token({'user_id': user.id})
             return jsonify({"message": "Login Successful",
                             "token": token.decode()})

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -208,3 +208,12 @@ def test_auth_overtime_as_student(client):
 
     assert resp.status_code == 200
     assert resp.get_json()['message'] == 'Login Successful'
+
+
+def test_auth_admin(client):
+    """test to login as admin without reCAPTCHA
+        target_url: /auth
+    """
+    resp = login(client, admin['secret_id'], '')
+
+    assert resp['message'] == 'Login Successful'

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -29,6 +29,10 @@ def test_login(client):
     assert 'Login Successful' in resp['message']
     resp = login(client, 'notexist', 'notexist')
     assert 'Login unsuccessful' in resp['message']
+    with mock.patch('api.routes.auth.json.loads',
+                    return_value={'success': False,
+                                  'error-codes': ['invalid-input-secret']}):
+        assert 'Login unsuccessful' in resp['message']
 
 
 def test_login_form(client):


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * `admin`で`/auth`を叩いた際、reCAPTCHA認証をスルーします。
  * #158

修正前の挙動:
-------------

  * adminのトークンもreCAPTCHA通さないと作れなかった

修正後の挙動:
-------------

  * reCAPTCHAなしで行けるようになる

影響範囲
================