### PR TITLE
`get_prev_time_index`追加-#193

### DIFF
--- a/api/time_management.py
+++ b/api/time_management.py
@@ -96,3 +96,31 @@ def get_time_index(time=None):
             return i
 
     raise OutOfAcceptingHoursError()
+
+
+def get_prev_time_index(time=None):
+    """
+        get the previous lottery index from the time
+        args:
+          time(datetime.time|datetime.datetime): the time
+        return:
+          i(int): the lottery index
+        raises:
+          OutOfHoursError, OutOfAcceptingHoursError
+
+        the graphical description for this method is
+        in the commit note of commit 3fb5c1a .
+        See it if you confusing how to imagine this work.
+        And also, it lived in the commit message,
+        but it was wrong. so DON'T REFER TO COMMIT MESSAGE
+    """
+    time = _validate_and_get_time(time)
+    en_margin = current_app.config['TIMEPOINT_END_MARGIN']
+    ends = [mod_time(time_point[1], en_margin) for time_point
+            in current_app.config['TIMEPOINTS']]
+
+    for i in range(len(ends)-1):
+        if ends[i] <= time < ends[i+1]:
+            return i
+
+    raise OutOfAcceptingHoursError()

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -5,6 +5,7 @@ from api.time_management import (
     mod_time,
     get_draw_time_index,
     get_time_index,
+    get_prev_time_index,
     OutOfHoursError,
     OutOfAcceptingHoursError
 )
@@ -101,3 +102,47 @@ def test_time_index_same(client):
             assert i == idx_l
             idx_r = get_time_index(point[1])
             assert i == idx_r
+
+
+def test_prev_time_index_ooa(client):
+    with client.application.app_context():
+        start_of_first_index = client.application.config['TIMEPOINTS'][0][0]
+        end_of_last_index = client.application.config['TIMEPOINTS'][-1][1]
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
+        res = mod_time(datetime.timedelta.resolution, en_margin)
+        with pytest.raises(OutOfAcceptingHoursError):
+            get_prev_time_index(mod_time(start_of_first_index, res))
+        with pytest.raises(OutOfAcceptingHoursError):
+            get_prev_time_index(mod_time(end_of_last_index, res))
+
+
+def test_prev_time_index_lim(client):
+    with client.application.app_context():
+        res = datetime.timedelta.resolution
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
+        ends = [mod_time(tp[1], en_margin) for tp
+                in client.application.config['TIMEPOINTS']]
+        for i in range(len(ends)-1):
+            idx_l = get_prev_time_index(mod_time(ends[i], res))
+            assert i == idx_l
+            idx_r = get_prev_time_index(mod_time(ends[i+1], -res))
+            assert i == idx_r
+
+
+def test_prev_time_index_same(client):
+    with client.application.app_context():
+        res = datetime.timedelta.resolution
+        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
+        ends = [mod_time(tp[1], en_margin) for tp
+                in client.application.config['TIMEPOINTS']]
+        for i in range(len(ends)-1):
+            if i == len(ends)-1:
+                idx_l = get_prev_time_index(ends[i])
+                assert i == idx_l
+                with pytest.raises(OutOfAcceptingHoursError):
+                                get_prev_time_index(ends[i+1])
+            else:
+                idx_l = get_prev_time_index(ends[i])
+                assert i == idx_l
+                idx_r = get_prev_time_index(mod_time(ends[i+1], -res))
+                assert i == idx_r


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
 * Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0: Thu
Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@237b63d1b441a96ac14c55dca3ccde9bb04c1a32
 * Sakuten/backend@8fa75c5e9c2a0a00169cc3b51d39c5fdebb90583


変更内容
================

  * *一つ前のindexを返す*関数`get_prev_time_index`を作成しました。
  * 正確には、*ある`index`の`TIMEPOINT+MARGIN`の時間から次の`index`の`TIMEPOINT+MARGIN`までの間、その`index`を返す*という仕様です。
  * 挙動がわかりづらすぎるので図を貼っておきます。
  * 尚、このような仕様になったのは時短のためと、#183で使用する目的で作られていたからです。
  * #193

図:
```
|-- TIME_POINTS[0]
|
|             |-- TIME_POINTS[1]
|             |
|             ||-- TIMEPOINT_END_MARGIN
|             ||
|             ||   |-- DRAWWING_TIME EXTENSION
|             ||   |
|             ||   |       |-- Void time (annoucements, the show is going...)
|             ||   |       |
v  index: x   vv   v       v          index: y                        index: z
|=============|-|******|         |=============|-|******|         |=============|-|
                |++++++++++++++++++++++++++++++++|
                                                 |________________________________|

In the range of |+|,  `get_prev_time_index` will return `x`.
In the range of |_|,  `get_prev_time_index` will return `y`.
```

修正前の挙動:
-------------

  * `get_prev_time_index`がない


修正後の挙動:
-------------

  * `get_prev_time_index`がある

影響範囲
================

  * なし