### PR TITLE
checkerエンドポイントで一つ前のindexを参照するように変更

### DIFF
--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -18,7 +18,8 @@ from api.time_management import (
     get_draw_time_index,
     OutOfHoursError,
     OutOfAcceptingHoursError,
-    get_time_index
+    get_time_index,
+    get_prev_time_index
 )
 from api.draw import (
     draw_one,
@@ -389,7 +390,7 @@ def check_id(classroom_id, secret_id):
     if not user:
         return error_response(5)  # no such user found
     try:
-        index = get_time_index()
+        index = get_prev_time_index()
     except (OutOfHoursError, OutOfAcceptingHoursError):
         return error_response(6)  # not acceptable time
     lottery = Lottery.query.filter_by(classroom_id=classroom_id,

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -24,7 +24,7 @@ def test_checker(client, def_status):
         db.session.add(application)
         db.session.commit()
 
-    with mock.patch('api.routes.api.get_time_index',
+    with mock.patch('api.routes.api.get_prev_time_index',
                     return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],
@@ -44,7 +44,7 @@ def test_checker_no_application(client):
     secret_id = target_user['secret_id']
     staff = checker
 
-    with mock.patch('api.routes.api.get_time_index',
+    with mock.patch('api.routes.api.get_prev_time_index',
                     return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],
@@ -61,7 +61,7 @@ def test_checker_invalid_user(client):
     staff = checker
     secret_id = "NOTEXIST_SECRET_KEY"
 
-    with mock.patch('api.routes.api.get_time_index',
+    with mock.patch('api.routes.api.get_prev_time_index',
                     return_value=index):
         resp = as_user_get(client, staff['secret_id'],
                            staff['g-recaptcha-response'],


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * `checker`は、抽選が終わった後のindexに対して処理をする必要があるため、使用する`index`は一つ前のものにならなければいけません。
  * ですが元々、*現在の`index`*を参照するようになっていました。
  * そのため、*一つ前の`index`を参照するように変更しました。
  * #192

修正前の挙動:
-------------

  * `/checker`エンドポイントが、使わなければいけない時間に動かなくなっていた

修正後の挙動:
-------------

  * `/checker`エンドポイントが、使わなければいけない時間に動くようになった

影響範囲
================

  * 特になし