### PR TITLE
`get_prev_time_index`の挙動を修正

### DIFF
--- a/api/time_management.py
+++ b/api/time_management.py
@@ -123,7 +123,7 @@ def get_prev_time_index(time=None):
         if ends[i] <= time < ends[i+1]:
             return i
 
-    if ends[:-1] <= time:
+    if ends[-1] <= time:
         return len(current_app.config['TIMEPOINTS']) - 1
 
     raise OutOfAcceptingHoursError()

--- a/api/time_management.py
+++ b/api/time_management.py
@@ -123,4 +123,7 @@ def get_prev_time_index(time=None):
         if ends[i] <= time < ends[i+1]:
             return i
 
+    if ends[:-1] <= time:
+        return len(current_app.config['TIMEPOINTS']) - 1
+
     raise OutOfAcceptingHoursError()

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -126,21 +126,3 @@ def test_prev_time_index_lim(client):
             idx_r = get_prev_time_index(mod_time(ends[i+1], -res))
             assert i == idx_r
 
-
-def test_prev_time_index_same(client):
-    with client.application.app_context():
-        res = datetime.timedelta.resolution
-        en_margin = client.application.config['TIMEPOINT_END_MARGIN']
-        ends = [mod_time(tp[1], en_margin) for tp
-                in client.application.config['TIMEPOINTS']]
-        for i in range(len(ends)-1):
-            if i == len(ends)-1:
-                idx_l = get_prev_time_index(ends[i])
-                assert i == idx_l
-                with pytest.raises(OutOfAcceptingHoursError):
-                                get_prev_time_index(ends[i+1])
-            else:
-                idx_l = get_prev_time_index(ends[i])
-                assert i == idx_l
-                idx_r = get_prev_time_index(mod_time(ends[i+1], -res))
-                assert i == idx_r

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -121,8 +121,10 @@ def test_prev_time_index_lim(client):
         ends = [mod_time(tp[1], en_margin) for tp
                 in client.application.config['TIMEPOINTS']]
         for i in range(len(ends)-1):
-            idx_l = get_prev_time_index(mod_time(ends[i], res))
+            idx_l = get_prev_time_index(ends[i])
             assert i == idx_l
             idx_r = get_prev_time_index(mod_time(ends[i+1], -res))
             assert i == idx_r
 
+        idx_l = get_prev_time_index(ends[-1])
+        assert len(ends)-1 == idx_l

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -112,8 +112,6 @@ def test_prev_time_index_ooa(client):
         res = mod_time(datetime.timedelta.resolution, en_margin)
         with pytest.raises(OutOfAcceptingHoursError):
             get_prev_time_index(mod_time(start_of_first_index, res))
-        with pytest.raises(OutOfAcceptingHoursError):
-            get_prev_time_index(mod_time(end_of_last_index, res))
 
 
 def test_prev_time_index_lim(client):

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -107,7 +107,6 @@ def test_time_index_same(client):
 def test_prev_time_index_ooa(client):
     with client.application.app_context():
         start_of_first_index = client.application.config['TIMEPOINTS'][0][0]
-        end_of_last_index = client.application.config['TIMEPOINTS'][-1][1]
         en_margin = client.application.config['TIMEPOINT_END_MARGIN']
         res = mod_time(datetime.timedelta.resolution, en_margin)
         with pytest.raises(OutOfAcceptingHoursError):


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * 最後の`TIME_POINTS`の後、`index`が返されなかったのを修正
  * #204

修正前の挙動:
-------------

  * 最後の`TIME_POINTS`後、`index`を取得できなかった

修正後の挙動:
-------------

  * 最後の`TIME_POINTS`後、`index`を取得できる

影響範囲
================

  * 今回の変更部分**以外**に、この変更が影響を与えそうなところがあったら書いてください