### PR TITLE
test_users.jsonのauthorityとkindの矛盾を修正

### DIFF
--- a/cards/test_users.json
+++ b/cards/test_users.json
@@ -9,13 +9,13 @@
         "secret_id": "excGkN88o8eN61NbZpHMfJK0HgThsX9N",
         "public_id": "5RAX",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "zmPplhO29m7dMNDdLnt4MtO_aFONrViC",
         "public_id": "4YMY",
         "authority": "normal",
-        "kind": "visitor"
+        "kind": "student"
     },
     {
         "secret_id": "TFdC-Ckz30CmhRS8PozhwgT5qM6t1q3I",
@@ -45,13 +45,13 @@
         "secret_id": "6ys5vXbm_J4WKXlvdVEFhLIM_b9XMtca",
         "public_id": "3EPE",
         "authority": "normal",
-        "kind": "checker"
+        "kind": "visitor"
     },
     {
         "secret_id": "c148WsrQP5xFKUNNvUWCL1gxAVDRJ_KZ",
         "public_id": "6FEH",
         "authority": "normal",
-        "kind": "checker"
+        "kind": "visitor"
     },
     {
         "secret_id": "bzF2xstsEc7SmiV0RCGiIml8TvlcWbGb",


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
  * OSのバージョン: _____
  * devenvのハッシュ: _____
  * frontendのハッシュ: _____
  * backendのハッシュ: _____

変更内容
================

  * `kind=checker`且つ`authority=normal`なユーザーがいたため、`kind=visitor`に修正
  * それに伴い、`kind=student`のユーザーも少し増やしました（元々一つしかなかったため）
  * `authority`を変更しなかった理由は、`checker`をもつidは一つということに決まったからです
  * #206

修正前の挙動:
-------------

  * `kind`と`authority`が矛盾したユーザーがいた

修正後の挙動:
-------------

  * `kind`と`authority`の矛盾が解消された

影響範囲
================

  * なし