### PR TITLE
Public IDの重複に対応

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -15,7 +15,7 @@ class User(db.Model):
             secret_id (int): secret id.
     """
     id = db.Column(db.Integer, primary_key=True)
-    public_id = db.Column(db.Integer, unique=True)
+    public_id = db.Column(db.Integer)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
     kind = db.Column(db.String(30))

--- a/cards/id.py
+++ b/cards/id.py
@@ -52,34 +52,6 @@ def decode_public_id(str_id):
     return sum(alphas[i] * 18**(3-i) for i in range(4))
 
 
-def find_public_id(ids, secret_id):
-    """
-        search for the public ID that corresponds to the given secret ID
-        Args:
-            ids (list): list of dictionaries that contains IDs
-            secret_id (str): token (target)
-        Return:
-            public_id (str): 4-letter ID
-    """
-    for id_dict in ids:
-        if id_dict["secret_id"] == secret_id:
-            return id_dict["public_id"]
-
-
-def find_secret_id(ids, public_id):
-    """
-        search for the secret ID that corresponds to the given public ID
-        Args:
-            ids (list): list of dictionaries that contains IDs
-            secret_id (str): 4-letter ID (target)
-        Return:
-            public_id (str): token
-    """
-    for id_dict in ids:
-        if id_dict["public_id"] == public_id:
-            return id_dict["secret_id"]
-
-
 def generate_ids(how_many):
     """
         generate a list of dictionaries that have a pair of


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
 * Linux masato-laptop 4.15.0-34-generic#37-Ubuntu SMP Mon Aug 27 15:21:48 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@bc0fbefda7bd3312428acba83ed05937f9049e3d
 * Sakuten/backend@a54bc41f3f320b46143e6d367c3d477573fa1fbe


変更内容
================

  * IDのJSONファイルでPublic IDの重複が発覚したため対応
  * ID周りの使われていない関数を削除

修正前の挙動:
-------------

  * Public IDが重複舌状態でデータベースに保存しようとするとエラーが発生する
（`public_id`に`unique=True`が設定されているため）

修正後の挙動:
-------------

  * Public IDの重複したUserを扱える
（`unique=True`を削除）

影響範囲
================

  * `User.query.filter_by(public_id=id)`が複数の値を含むので
安易に`User.query.filter_by(public_id=id).first()`と`first`を呼び出すべきではありません
こんなコードはこのリポジトリにはありませんが
