### PR TITLE
日付変更によるUser無効化時に別のエラーを返す-#199

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -8,6 +8,20 @@ from api.time_management import get_current_datetime
 from api.error import error_response
 
 
+class UserNotFound(Exception):
+    """
+        The Exception that indicates the user was not found
+    """
+    pass
+
+
+class UserDisabled(Exception):
+    """
+        The Exception that indicates the user was not found
+    """
+    pass
+
+
 def generate_token(obj):
     """
         generate token and expiration, return it.
@@ -76,7 +90,7 @@ def login_required(*required_authority):
             data = decrypt_token(token)
             if not data:
                 return auth_error(0, 'error="invalid_token"')
-            user, _ = todays_user(user_id=data['data']['user_id'])
+            user = todays_user(user_id=data['data']['user_id'])
             if user is None:
                 return auth_error(0, 'realm="id_disabled"')
             if required_authority and \
@@ -96,9 +110,10 @@ def todays_user(secret_id='', user_id=''):
             secret_id (str): secret id of target user
         Return:
             User (api.models.User): the user object of 'secret_id'
-            (None, error_num) (tuple):
-                this is returned when some error has been occured
-                error_num (int): error_code defined in error.json. [5|22]
+            None : this is returned when some error has been occured
+        Exceptions:
+            UserNotFound : when user was not found in DB
+            UserDisabled : when user was diabled
 
         References are here:
             https://github.com/Sakuten/backend/issues/78#issuecomment-416609508
@@ -110,16 +125,15 @@ def todays_user(secret_id='', user_id=''):
         user = User.query.get(user_id)
 
     if not user:
-        return None, 3
+        raise UserNotFound()
     if user.kind not in current_app.config['ONE_DAY_KIND']:
-        return user, None
-
+        return user
     if user.first_access is None:
         user.first_access = date.today()
         db.session.add(user)
         db.session.commit
-        return user, None
+        return user
     elif user.first_access == date.today():
-        return user, None
+        return user
     else:
-        return None, 22
+        raise UserDisabled()

--- a/api/auth.py
+++ b/api/auth.py
@@ -76,7 +76,7 @@ def login_required(*required_authority):
             data = decrypt_token(token)
             if not data:
                 return auth_error(0, 'error="invalid_token"')
-            user = todays_user(user_id=data['data']['user_id'])
+            user, _ = todays_user(user_id=data['data']['user_id'])
             if user is None:
                 return auth_error(0, 'realm="id_disabled"')
             if required_authority and \

--- a/api/auth.py
+++ b/api/auth.py
@@ -96,7 +96,9 @@ def todays_user(secret_id='', user_id=''):
             secret_id (str): secret id of target user
         Return:
             User (api.models.User): the user object of 'secret_id'
-            None : when given 'secret_id' is used in other day
+            (None, error_num) (tuple):
+                this is returned when some error has been occured
+                error_num (int): error_code defined in error.json. [5|22]
 
         References are here:
             https://github.com/Sakuten/backend/issues/78#issuecomment-416609508
@@ -108,7 +110,7 @@ def todays_user(secret_id='', user_id=''):
         user = User.query.get(user_id)
 
     if not user:
-        return None
+        return (None, 3)
     if user.kind not in current_app.config['ONE_DAY_KIND']:
         return user
 
@@ -120,4 +122,4 @@ def todays_user(secret_id='', user_id=''):
     elif user.first_access == date.today():
         return user
     else:
-        return None
+        return (None, 22)

--- a/api/auth.py
+++ b/api/auth.py
@@ -110,16 +110,16 @@ def todays_user(secret_id='', user_id=''):
         user = User.query.get(user_id)
 
     if not user:
-        return (None, 3)
+        return None, 3
     if user.kind not in current_app.config['ONE_DAY_KIND']:
-        return user
+        return user, None
 
     if user.first_access is None:
         user.first_access = date.today()
         db.session.add(user)
         db.session.commit
-        return user
+        return user, None
     elif user.first_access == date.today():
-        return user
+        return user, None
     else:
-        return (None, 22)
+        return None, 22

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -151,7 +151,7 @@ def apply_lottery(idx):
         if len(group_members_secret_id) > 3:
             return error_response(21)
         for sec_id in group_members_secret_id:
-            user = todays_user(secret_id=sec_id)
+            (user, _) = todays_user(secret_id=sec_id)
             if user is not None:
                 group_members.append(user)
             else:

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -12,7 +12,7 @@ from api.schemas import (
     lotteries_schema,
     lottery_schema
 )
-from api.auth import login_required, todays_user
+from api.auth import login_required, todays_user, UserNotFound, UserDisabled
 from api.swagger import spec
 from api.time_management import (
     get_draw_time_index,
@@ -151,12 +151,11 @@ def apply_lottery(idx):
         if len(group_members_secret_id) > 3:
             return error_response(21)
         for sec_id in group_members_secret_id:
-            user, _ = todays_user(secret_id=sec_id)
-            if user is not None:
-                group_members.append(user)
-            else:
+            try:
+                user = todays_user(secret_id=sec_id)
+            except (UserNotFound, UserDisabled):
                 return error_response(1)  # Invalid group member secret id
-
+            group_members.append(user)
         for user in group_members:
             previous = Application.query.filter_by(user_id=user.id)
             if any(app.lottery.index == lottery.index and

--- a/api/routes/api.py
+++ b/api/routes/api.py
@@ -151,7 +151,7 @@ def apply_lottery(idx):
         if len(group_members_secret_id) > 3:
             return error_response(21)
         for sec_id in group_members_secret_id:
-            (user, _) = todays_user(secret_id=sec_id)
+            user, _ = todays_user(secret_id=sec_id)
             if user is not None:
                 group_members.append(user)
             else:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -31,7 +31,7 @@ def home():
     # login flow
     secret_id = data.get('id')
     recaptcha_code = data.get('g-recaptcha-response')
-    (user, err_num) = todays_user(secret_id=secret_id)
+    user, err_num = todays_user(secret_id=secret_id)
     if not user:
         return error_response(err_num)
     if not ip_address(request.remote_addr).is_private:

--- a/errors.json
+++ b/errors.json
@@ -86,5 +86,9 @@
   "21": {
     "message": "too many group members",
     "status": 400
+  },
+  "22": {
+    "message": "This user_id is already used in other day",
+    "status": 400
   }
 }

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -187,7 +187,8 @@ def test_auth_used_user(client):
                            }, follow_redirects=True)
 
     assert resp.status_code == 400
-    assert resp.get_json()['message'] == 'Login unsuccessful'
+    assert resp.get_json()['message'] == 'This user_id is ' \
+                                         'already used in other day'
 
 
 def test_auth_overtime_as_student(client):


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

 * Darwin crystalslate.local 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@90463615e7ce6d65235ff626a666e27d17fdfd33
 * Sakuten/backend@65128d4829521c623dfd5fe02eead44056e2fe6e

変更内容
================

  * `user`が無効化されていた場合、その旨の別のエラーを返す
  * 具体的には`error_num: 22`/`This user_id is already used in other day`が返されます。
  * #199
  * Sakuten/rfcs#3, Sakuten/rfcs#4

修正前の挙動:
-------------

  * `user_id`が無効なのか、間違っているのかがわからない

修正後の挙動:
-------------

  * `user_id`が無効なのか、間違っているのかがわかる

影響範囲
================

  * なし