### PR TITLE
Use CircleCI to push docker image to dockerhub automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:17.07.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Setup Environment Variables
+          command: |
+            echo "export DOCKER_IMAGE_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)" >> $BASH_ENV
+      - run:
+          name: Login
+          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+      - run:
+          name: Build image
+          command: docker build -t ${DOCKER_IMAGE_NAME} .
+      - run:
+          name: Push
+          command: docker push ${DOCKER_IMAGE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,15 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Setup Environment Variables
-          command: |
-            echo "export DOCKER_IMAGE_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)" >> $BASH_ENV
-      - run:
           name: Login
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
           name: Build image
-          command: docker build -t ${DOCKER_IMAGE_NAME} .
+          command: |
+            DOCKER_IMAGE_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)
+            docker build -t ${DOCKER_IMAGE_NAME} .
       - run:
           name: Push
-          command: docker push ${DOCKER_IMAGE_NAME}
+          command: |
+            DOCKER_IMAGE_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)
+            docker push ${DOCKER_IMAGE_NAME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
   - "3.6"
-sudo: false
+sudo: required
+services:
+  - docker
 before_install:
   - pip install pipenv
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ script:
   - pipenv run test
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - |
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    export DOCKER_TAG_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)
+    docker build . -t $DOCKER_TAG_NAME
+    docker push $DOCKER_TAG_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,3 @@ script:
   - pipenv run test
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-  - |
-    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    export DOCKER_TAG_NAME=sakuten/backend:$(./scripts/ci/docker_tag_name.sh)
-    docker build . -t $DOCKER_TAG_NAME
-    docker push $DOCKER_TAG_NAME

--- a/scripts/ci/docker_tag_name.sh
+++ b/scripts/ci/docker_tag_name.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! "$TRAVIS" ]; then
+  echo "Hey, This script works only in Travis CI enviroment."
+  echo "Don't run this locally."
+  exit -1
+fi
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "pr_$TRAVIS_PULL_REQUEST"
+  exit
+fi

--- a/scripts/ci/docker_tag_name.sh
+++ b/scripts/ci/docker_tag_name.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
 
-if [ ! "$TRAVIS" ]; then
-  echo "Hey, This script works only in Travis CI enviroment."
+if [ ! "$CIRCLECI" ]; then
+  echo "Hey, This script works only in Circle CI enviroment."
   echo "Don't run this locally."
   exit -1
 fi
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo "pr_$TRAVIS_PULL_REQUEST"
+if [ "$CIRCLE_PR_NUMBER" ]; then
+  echo "pr_$CIRCLE_PR_NUMBER"
   exit
 fi
 
-if [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$CIRCLE_TAG" ]; then
+  echo "$CIRCLE_TAG"
+  exit
+fi
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
   echo "latest"
   exit
 fi
 
 
-echo "$TRAVIS_BRANCH" | sed 's/[^[:alnum:]._-]/_/g'
+echo "$CIRCLE_BRANCH" | sed 's/[^[:alnum:]._-]/_/g'
 exit

--- a/scripts/ci/docker_tag_name.sh
+++ b/scripts/ci/docker_tag_name.sh
@@ -10,3 +10,12 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo "pr_$TRAVIS_PULL_REQUEST"
   exit
 fi
+
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo "latest"
+  exit
+fi
+
+
+echo "$TRAVIS_BRANCH" | sed 's/[^[:alnum:]._-]/_/g'
+exit

--- a/scripts/ci/docker_tag_name.sh
+++ b/scripts/ci/docker_tag_name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! "$CIRCLECI" ]; then
   echo "Hey, This script works only in Circle CI enviroment."


### PR DESCRIPTION

変更内容
================

  * CircleCIで、普通のDockerHubリポジトリにプッシュする
  * Automated Buildと同等のことをしながら、マニュアルpushもできるので緊急時に強い
  * ビルドの進捗が観れる安心感
  * そもそも速いので優勝

修正前の挙動:
-------------

  * DockerHubのAutomated Build
  * 遅い
　* ローカルからpushできない

修正後の挙動:
-------------

  * ✨

影響範囲
================

  * ない
  * Travisにしようかと思ったが、これにマージブロックされたらたまったもんじゃないので。
