### PR TITLE
Get time-related configs from environment variable in production environment

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -73,6 +73,20 @@ class PreviewDeploymentConfig(BaseConfig):
 
 
 def _get_timepoints_from_json(json_str):
+    """
+        Get TIMEPOINTS list from JSON string.
+
+        Expected JSON looks like:
+        ```json
+        [
+          ["0:00", "5:59"],
+          ["6:00", "11:59"],
+          ["12:00", "17:59"],
+          ["18:00", "24:00"]
+        ]
+        ```
+    """
+
     return json_str and \
         [tuple(strptime(t, '%H:%M').time() for t in pair)
          for pair
@@ -80,6 +94,11 @@ def _get_timepoints_from_json(json_str):
 
 
 def _parse_datetime(datetime_str):
+    """
+        Parse datetime string to datetime,
+        and set BaseConfig.TIMEZONE
+    """
+
     return datetime_str and \
         strptime(datetime_str, '%Y-%m-%d %H:%M:%S') \
         .astimezone(BaseConfig.TIMEZONE)

--- a/api/config.py
+++ b/api/config.py
@@ -2,6 +2,8 @@ from cryptography.fernet import Fernet
 import os
 from pathlib import Path
 from datetime import datetime, time, timedelta, timezone, strptime
+import json
+
 import api
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -73,10 +73,17 @@ class PreviewDeploymentConfig(BaseConfig):
 
 
 def _get_timepoints_from_json(json_str):
-    return json_str and [tuple(strptime(t, '%H:%M').time() for t in pair) for pair in json.loads(json_str)]
+    return json_str and \
+        [tuple(strptime(t, '%H:%M').time() for t in pair)
+         for pair
+         in json.loads(json_str)]
+
 
 def _parse_datetime(datetime_str):
-    return datetime_str and strptime(datetime_str, '%Y-%m-%d %H:%M:%S').astimezone(BaseConfig.TIMEZONE)
+    return datetime_str and \
+        strptime(datetime_str, '%Y-%m-%d %H:%M:%S') \
+        .astimezone(BaseConfig.TIMEZONE)
+
 
 class DeploymentConfig(BaseConfig):
     DEBUG = False
@@ -84,6 +91,9 @@ class DeploymentConfig(BaseConfig):
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
     SECRET_KEY = os.environ.get('SECRET_KEY')
     ENV = 'production'
-    START_DATETIME = _parse_datetime(os.environ.get('START_DATETIME') or BaseConfig.START_DATETIME
-    END_DATETIME = _parse_datetime(os.environ.get('END_DATETIME') or BaseConfig.END_DATETIME
-    TIMEPOINTS = _get_timepoints_from_json(os.environ.get('TIMEPOINTS')) or BaseConfig.TIMEPOINTS
+    START_DATETIME = _parse_datetime(os.environ.get('START_DATETIME')) or \
+        BaseConfig.START_DATETIME
+    END_DATETIME = _parse_datetime(os.environ.get('END_DATETIME')) or \
+        BaseConfig.END_DATETIME
+    TIMEPOINTS = _get_timepoints_from_json(os.environ.get('TIMEPOINTS')) or \
+        BaseConfig.TIMEPOINTS

--- a/api/config.py
+++ b/api/config.py
@@ -70,9 +70,16 @@ class PreviewDeploymentConfig(BaseConfig):
     ]
 
 
+def _get_timepoints_from_json(json_str):
+    ary = json.loads(json_str)
+    return [tuple(strptime(t, '%H:%M').time() for t in pair) for pair in ary]
+
 class DeploymentConfig(BaseConfig):
     DEBUG = False
     TESTING = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
     SECRET_KEY = os.environ.get('SECRET_KEY')
     ENV = 'production'
+    START_DATETIME = os.environ.get('START_DATETIME', BaseConfig.START_DATETIME)
+    END_DATETIME = os.environ.get('END_DATETIME', BaseConfig.END_DATETIME)
+    TIMEPOINTS = _get_timepoints_from_json(os.environ.get('TIMEPOINTS')) or BaseConfig.TIMEPOINTS

--- a/api/config.py
+++ b/api/config.py
@@ -1,7 +1,7 @@
 from cryptography.fernet import Fernet
 import os
 from pathlib import Path
-from datetime import datetime, time, timedelta, timezone, strptime
+from datetime import datetime, time, timedelta, timezone
 import json
 
 import api
@@ -88,7 +88,7 @@ def _get_timepoints_from_json(json_str):
     """
 
     return json_str and \
-        [tuple(strptime(t, '%H:%M').time() for t in pair)
+        [tuple(datetime.strptime(t, '%H:%M').time() for t in pair)
          for pair
          in json.loads(json_str)]
 
@@ -100,7 +100,7 @@ def _parse_datetime(datetime_str):
     """
 
     return datetime_str and \
-        strptime(datetime_str, '%Y-%m-%d %H:%M:%S') \
+        datetime.strptime(datetime_str, '%Y-%m-%d %H:%M:%S') \
         .astimezone(BaseConfig.TIMEZONE)
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -1,7 +1,7 @@
 from cryptography.fernet import Fernet
 import os
 from pathlib import Path
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta, timezone, strptime
 import api
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -71,11 +71,10 @@ class PreviewDeploymentConfig(BaseConfig):
 
 
 def _get_timepoints_from_json(json_str):
-    ary = json.loads(json_str)
-    return [tuple(strptime(t, '%H:%M').time() for t in pair) for pair in ary]
+    return json_str and [tuple(strptime(t, '%H:%M').time() for t in pair) for pair in json.loads(json_str)]
 
 def _parse_datetime(datetime_str):
-    return strptime(datetime_str, '%Y-%m-%d %H:%M:%S').astimezone(BaseConfig.TIMEZONE)
+    return datetime_str and strptime(datetime_str, '%Y-%m-%d %H:%M:%S').astimezone(BaseConfig.TIMEZONE)
 
 class DeploymentConfig(BaseConfig):
     DEBUG = False

--- a/api/config.py
+++ b/api/config.py
@@ -74,12 +74,15 @@ def _get_timepoints_from_json(json_str):
     ary = json.loads(json_str)
     return [tuple(strptime(t, '%H:%M').time() for t in pair) for pair in ary]
 
+def _parse_datetime(datetime_str):
+    return strptime(datetime_str, '%Y-%m-%d %H:%M:%S').astimezone(BaseConfig.TIMEZONE)
+
 class DeploymentConfig(BaseConfig):
     DEBUG = False
     TESTING = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
     SECRET_KEY = os.environ.get('SECRET_KEY')
     ENV = 'production'
-    START_DATETIME = os.environ.get('START_DATETIME', BaseConfig.START_DATETIME)
-    END_DATETIME = os.environ.get('END_DATETIME', BaseConfig.END_DATETIME)
+    START_DATETIME = _parse_datetime(os.environ.get('START_DATETIME') or BaseConfig.START_DATETIME
+    END_DATETIME = _parse_datetime(os.environ.get('END_DATETIME') or BaseConfig.END_DATETIME
     TIMEPOINTS = _get_timepoints_from_json(os.environ.get('TIMEPOINTS')) or BaseConfig.TIMEPOINTS


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@b1fcb349262b41331588f7b7ef22cd66417f0252
 * Sakuten/backend@8f464004352aa6a89f7e090e1d9bbc4156cae048

変更内容
================

  * 時間関係の設定項目を環境変数から取れるようにする
  * インフラ側から設定できるので
  * すぐ修正できるし設定項目の一元化にもなる
  * `TIMEPOINTS`は、jsonで与える

修正前の挙動:
-------------

  * イメージの時点で固定

修正後の挙動:
-------------

  * かえれる

影響範囲
================

  * ない
