### PR TITLE
`is_member`の追加

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -40,10 +40,19 @@ class ApplicationSchema(Schema):
     lottery = fields.Method("get_lottery", dump_only=True)
     is_rep = fields.Boolean()
     group_members = fields.Nested(GroupMemberSchema, many=True)
+    is_member = fields.Method("get_is_member", dump_only=True)
 
     def get_lottery(self, application):
         lottery = Lottery.query.get(application.lottery_id)
         return lottery_schema.dump(lottery)[0]
+
+    def get_is_member(self, application):
+        index = application.lottery.index
+        reps = (app for app in Application.query.all()
+                if app.is_rep and app.lottery.index == index)
+        return any(application.id == member.own_application.id
+                   for rep in reps
+                   for member in rep.group_members)
 
 
 application_schema = ApplicationSchema()

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,0 +1,37 @@
+from api.models import User, Lottery, Application, group_member, db
+from api.schemas import application_schema
+
+
+def test_application_is_member(client):
+    with client.application.app_context():
+        target_lot = Lottery.query.first()
+
+        users = User.query.all()
+        member = users[0]
+
+        member_app = Application(lottery=target_lot, user=member)
+        rep = users[1]
+        rep_app = Application(lottery=target_lot, user=rep, is_rep=True,
+                              group_members=[group_member(member_app)])
+
+        db.session.add(member_app)
+        db.session.add(rep_app)
+        db.session.commit()
+
+        dumpdata = application_schema.dump(member_app)[0]
+        assert dumpdata['is_member']
+
+
+def test_application_not_member(client):
+    with client.application.app_context():
+        target_lot = Lottery.query.first()
+
+        member = User.query.first()
+
+        member_app = Application(lottery=target_lot, user=member)
+
+        db.session.add(member_app)
+        db.session.commit()
+
+        dumpdata = application_schema.dump(member_app)[0]
+        assert not dumpdata['is_member']


### PR DESCRIPTION
 * Linux masato-laptop 4.15.0-34-generic#37-Ubuntu SMP Mon Aug 27 15:21:48 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@6fa48c7429eb165b219072cca52224caf7f78478
 * Sakuten/backend@f8e987f8c3338402cffb872fb28fc21fea278132

変更内容
================

  * #220

修正後の挙動:
-------------

Applicationのdumpに`is_member`がある
団体応募のメンバーかどうか返す
個人・代表者はFalse
group_memberはTrue

影響範囲
================

  * フロント
要求はこれで合ってますか？
