### PR TITLE
テストがことごとく落ちる

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -23,8 +23,8 @@ class BaseConfig(object):
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY')
     RECAPTCHA_THRESHOLD = 0.09  # more than 0.09
     TIMEZONE = timezone(timedelta(hours=+9), 'JST')
-    START_DATETIME = datetime(2018, 9, 16, 8,  40, 0, tzinfo=TIMEZONE)
-    END_DATETIME = datetime(2018, 9, 17, 16, 00, 0, tzinfo=TIMEZONE)
+    START_DATETIME = datetime(2019, 9, 15, 8,  40, 0, tzinfo=TIMEZONE)
+    END_DATETIME = datetime(2019, 9, 16, 16, 00, 0, tzinfo=TIMEZONE)    # 敬老の日
     DRAWING_TIME_EXTENSION = timedelta(minutes=10)
     TIMEPOINT_END_MARGIN = timedelta(minutes=1)
     TIMEPOINTS = [

--- a/test/test_lottery.py
+++ b/test/test_lottery.py
@@ -930,7 +930,7 @@ def test_losers_advantage(client):
     idx = 1
     win_count = {i: 0 for i in range(1, 7)}
 
-    for i in range(6):
+    for i in range(20):
         with client.application.app_context():
             target_lottery = Lottery.query.get(idx)
             index = target_lottery.index


### PR DESCRIPTION
 * Linux masato-laptop 4.15.0-34-generic#37-Ubuntu SMP Mon Aug 27 15:21:48 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@3c2a4f4c358909119f28aa820e475696b25fca48
 * Sakuten/backend@f7337f307f55f0856eebab473add2368bc5659eb

変更内容
================
#246 

修正後の挙動:
-------------

テストが正しく動くようになる

なんか警告たくさん出てるのは別issueとして対応します
これは急ぎテストが（一応）働いて、作業がまともにできるようにするためのものです
