### PR TITLE
pyyamlのwarningに対応

### DIFF
--- a/api/swagger.py
+++ b/api/swagger.py
@@ -4,7 +4,7 @@ import yaml
 import api
 
 with open(os.path.join(api.__path__[0], 'spec/template.yml')) as f:
-    template = yaml.load(f)
+    template = yaml.load(f, Loader=yaml.FullLoader)
 swag = Swagger(template=template)
 
 


### PR DESCRIPTION
参照:
  https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)


<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

変更内容
================

  * `pyyaml`由来のWarningを解消します。
  * テストの際は発生せず、本番環境のみで発生するwarningでした。
  * インジェクションの脆弱性でしたが、以下の理由により特段推奨されているものへの変更はしません。(warning解消のみ)
   * 今回読み込んでいるyamlはこちらで用意したもの(`swagger`のためのテンプレートファイル)であり、参照先のパスもシステム側で決まっていてインジェクションされる余地がない。
   * ドキュメントによれば`SafeLoader`は「未知の入力の対して使え」とのことなので今回はパス

修正前の挙動:
-------------

  * 実行時`pyyaml`からのwarningが出た

修正後の挙動:
-------------

  * 実行時`pyyaml`からのwarningが出ない

影響範囲
================

  * 特になし