### PR TITLE
警告を消す

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 flask-sqlalchemy = "*"
+sqlalchemy = "<1.2.16"
 marshmallow = "*"
 flask-cors = "*"
 cryptography = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "367d3410021ddd75c6f652141cc4ea722719da49d0ce5074e944e2c40466be1a"
+            "sha256": "0d67dfb4fb6faea9379769a5c5d4762350544bb02132fa879ee82b0d8e8ae95c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -83,6 +83,14 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "cryptography": {
             "hashes": [
@@ -205,11 +213,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:f2668d41a817aaaf6106d9922479bd1a97cae240dfac0eb7e320e0c29148a084",
-                "sha256:f8e51314623247b5c444e460b2bbb04aee102ca1ce7fb27bb16e3107cb81dfe9"
+                "sha256:01412e979b45c003aeb3632718780b15b01566ae0182cc9232434b30f6b85e1b",
+                "sha256:8a1a2e13c6a621f4970faf21e5d9b146e451e779d0f334a96eae4fcdef53455f"
             ],
             "index": "pypi",
-            "version": "==2.19.0"
+            "version": "==2.19.1"
         },
         "mistune": {
             "hashes": [
@@ -401,9 +409,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:781fb7b9d194ed3fc596b8f0dd4623ff160e3e825dd8c15472376a438c19598b"
+                "sha256:809547455d012734b4252081db1e6b4fc731de2299f3755708c39863625e1c77"
             ],
-            "version": "==1.3.1"
+            "index": "pypi",
+            "version": "==1.2.15"
         },
         "watchdog": {
             "hashes": [
@@ -414,10 +423,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:96da23fa8ccecbc3ae832a83df5c722c11547d021637faacb0bec4dd2f4666c8",
+                "sha256:ca5c2dcd367d6c0df87185b9082929d255358f5391923269335782b213d52655"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.1"
         }
     },
     "develop": {
@@ -463,6 +472,14 @@
                 "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
             "version": "==2.1.1"
+        },
+        "v": {
+            "hashes": [
+                "sha256:2d5a8f79a36aaebe62ef2c7068e3ec7f86656078202edabfdbf74715dc822d36",
+                "sha256:cd6b6b20b4a611f209c88bcdfb7211321f85662efb2bdd53a7b40314d0a84618"
+            ],
+            "index": "pypi",
+            "version": "==0.0.0"
         }
     }
 }


### PR DESCRIPTION
 * Microsoft Windows NT 10.0.17134.0
 * Sakuten/devenv@8bd7d18d72106372d37e24a033673eaa3d2e8d0f
 * Sakuten/frontend@bc0fbefda7bd3312428acba83ed05937f9049e3d
 * Sakuten/backend@8de31ba57605177b668b4355d9ed9322e12f98ca

変更内容
================

  * fix #260 
  * SQLAlchemyがv1.2.16からdeprecation warningsを出し始めたので、バージョンをそれより前にします

修正前の挙動:
-------------

ユニットテスト時、1万を超えるwarnings

修正後の挙動:
-------------

警告たちがいなくなります

※こうなるためには、devenvで
```bash
docker-compose -f unit_test/docker-compose.yml build
```
しておく必要がありますが、これは少なくとも僕の環境では動きませんでした

ということで[devenv #52](https://github.com/Sakuten/devenv/pull/52)です

devenvで
```bash
$ git pull origin feature/shift-up-docker-context
$ docker-compose -f unit_test/docker-compose.yml build backend
```
した後にユニットテストをすると、警告がなくなっているはず…

うまく行っていれば、このPRのTravisは警告を出さないと思います。