### PR TITLE
public_idをuniqueとする

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -17,7 +17,7 @@ class User(db.Model):
             lose_count (int): how many times the user lost
     """
     id = db.Column(db.Integer, primary_key=True)
-    public_id = db.Column(db.Integer)
+    public_id = db.Column(db.Integer, unique=True)
     secret_id = db.Column(db.String(40), unique=True)
     authority = db.Column(db.String(20))
     win_count = db.Column(db.Integer, default=0)


### PR DESCRIPTION
 * Microsoft Windows NT 10.0.17134.0
 * Sakuten/devenv@bd8de28a0e5c44fa1c35890b3741cdee308475cf
 * Sakuten/frontend@39ce46806ea73890b2054c4a16c367a76fa30884
 * Sakuten/backend@47958daff7824303d45683a3fb06edb2d20d42f0

変更内容
================

  * issue: #182 pr: #209 を部分的にrevert

修正前の挙動:
-------------

  * public_idが重複していても文句を言わない

修正後の挙動:
-------------

  * エラーを出す

※cards/test_users.jsonには現在public_idの重複はなし
