### PR TITLE
Close #242: 1回の抽選時間に複数回/draw_allを叩いても結果が変わらないテスト追加

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -25,12 +25,15 @@ class BaseConfig(object):
     RECAPTCHA_THRESHOLD = 0.09  # more than 0.09
     TIMEZONE = timezone(timedelta(hours=+9), 'JST')
     # Don't forget to update START/END DATETIME every year
-    START_DATETIME = datetime(2019, 7, 16, 12, 00, 0, tzinfo=TIMEZONE)
-    END_DATETIME = datetime(2019, 7, 16, 13, 00, 0, tzinfo=TIMEZONE)
-    DRAWING_TIME_EXTENSION = timedelta(minutes=15)
+    START_DATETIME = datetime(2019, 9, 15, 8,  40, 0, tzinfo=TIMEZONE)
+    END_DATETIME = datetime(2019, 9, 16, 16, 00, 0, tzinfo=TIMEZONE)    # 敬老の日
+    DRAWING_TIME_EXTENSION = timedelta(minutes=10)
     TIMEPOINT_END_MARGIN = timedelta(minutes=1)
     TIMEPOINTS = [
-        (time(12, 15), time(12, 35)),
+        (time(8,  50), time(9,  20)),
+        (time(10, 15), time(10, 45)),
+        (time(12, 25), time(12, 55)),
+        (time(13, 50), time(14, 20))
     ]
     ONE_DAY_KIND = ['visitor']
 

--- a/api/config.py
+++ b/api/config.py
@@ -25,15 +25,12 @@ class BaseConfig(object):
     RECAPTCHA_THRESHOLD = 0.09  # more than 0.09
     TIMEZONE = timezone(timedelta(hours=+9), 'JST')
     # Don't forget to update START/END DATETIME every year
-    START_DATETIME = datetime(2019, 9, 15, 8,  40, 0, tzinfo=TIMEZONE)
-    END_DATETIME = datetime(2019, 9, 16, 16, 00, 0, tzinfo=TIMEZONE)    # 敬老の日
-    DRAWING_TIME_EXTENSION = timedelta(minutes=10)
+    START_DATETIME = datetime(2019, 7, 16, 12, 00, 0, tzinfo=TIMEZONE)
+    END_DATETIME = datetime(2019, 7, 16, 13, 00, 0, tzinfo=TIMEZONE)
+    DRAWING_TIME_EXTENSION = timedelta(minutes=15)
     TIMEPOINT_END_MARGIN = timedelta(minutes=1)
     TIMEPOINTS = [
-        (time(8,  50), time(9,  20)),
-        (time(10, 15), time(10, 45)),
-        (time(12, 25), time(12, 55)),
-        (time(13, 50), time(14, 20))
+        (time(12, 15), time(12, 35)),
     ]
     ONE_DAY_KIND = ['visitor']
 


### PR DESCRIPTION
 * MINGW64_NT-10.0 LAPTOP-93OTQDA5 2.11.2(0.329/5/3) 2018-11-10 14:38 x86_64 Msys
 * Sakuten/devenv@89dc1f55636831784c161fd71a2e7f9e9d7ddd0e
 * Sakuten/frontend@fbf5bfc9df5915369c507f25e5546ce152c94066
 * Sakuten/backend@e5a02df2cded1dfaaee9222aade360a8c8c0e5e0

変更内容
================

  * #242 
  * １`draw_time_index`に何度も`/draw_all`を叩いてしまっても、抽選結果が変わらないことをテストを追加し確認

修正後の挙動:
-------------

挙動の変化はなし（もともと結果は変わらなかった）

影響範囲
================

なし
