### PR TITLE
括弧付け忘れを直す

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -133,7 +133,7 @@ def todays_user(secret_id='', user_id=''):
     if user.first_access is None:
         user.first_access = date.today()
         db.session.add(user)
-        db.session.commit
+        db.session.commit()
         return user
     elif user.first_access == date.today():
         return user


### PR DESCRIPTION
 * MINGW64_NT-10.0 LAPTOP-93OTQDA5 2.11.2(0.329/5/3) 2018-11-10 14:38 x86_64 Msys
 * Sakuten/devenv@89dc1f55636831784c161fd71a2e7f9e9d7ddd0e
 * Sakuten/frontend@fbf5bfc9df5915369c507f25e5546ce152c94066
 * Sakuten/backend@7db0037c36cea845a083f9b5f1984ef005ec3da2

変更内容
================

括弧の付け忘れを治す

修正前の挙動:
-------------

初回利用のカードを使用済みとしてコミットするのが遅れる

修正後の挙動:
-------------

すぐコミットする

影響範囲
================

なし
